### PR TITLE
refactor: shouldLog interface

### DIFF
--- a/src/__tests__/evaluate.test.ts
+++ b/src/__tests__/evaluate.test.ts
@@ -19,8 +19,7 @@ const emptyResolver = new Resolver(
   [],
   projectEnvIdUnderTest,
   noNamespace,
-  "error",
-  3
+  "error"
 );
 
 describe.only("evaluate", () => {

--- a/src/__tests__/testHelpers.ts
+++ b/src/__tests__/testHelpers.ts
@@ -1,4 +1,8 @@
 import Long from "long";
+import { ConfigType } from "../proto";
+import type { Config } from "../proto";
+import { wordLevelToNumber, PREFIX } from "../logger";
+import type { ValidLogLevelName } from "../logger";
 
 export const nTimes = (n: number, fn: () => void): void => {
   for (let i = 0; i < n; i++) {
@@ -10,3 +14,28 @@ export const projectEnvIdUnderTest = new Long(5);
 export const emptyContexts = new Map();
 export const irrelevant = "this value does not matter";
 export const irrelevantLong = new Long(-1);
+
+export const levelAt = (path: string, level: string): Config => {
+  return {
+    id: irrelevantLong,
+    projectId: irrelevantLong,
+    key: `${PREFIX}${path}`,
+    changedBy: undefined,
+    rows: [
+      {
+        properties: {},
+        values: [
+          {
+            criteria: [],
+            value: {
+              logLevel: wordLevelToNumber(level as ValidLogLevelName),
+            },
+          },
+        ],
+      },
+    ],
+    allowableValues: [],
+    configType: ConfigType.LOG_LEVEL,
+    draftId: irrelevantLong,
+  };
+};

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -7,20 +7,9 @@ import { mergeContexts } from "./mergeContexts";
 import type { GetValue } from "./unwrap";
 import { evaluate } from "./evaluate";
 
-import { shouldLog } from "./logger";
-
 const emptyContexts: Contexts = new Map<string, Context>();
 
 export const NOT_PROVIDED = Symbol("NOT_PROVIDED");
-
-export const LogLevelLookup: Record<number, string> = {
-  1: "TRACE",
-  2: "DEBUG",
-  3: "INFO",
-  5: "WARN",
-  6: "ERROR",
-  9: "FATAL",
-};
 
 class Resolver implements PrefabInterface {
   private readonly config: Map<string, Config>;
@@ -28,14 +17,12 @@ class Resolver implements PrefabInterface {
   private readonly namespace: string | undefined;
   private readonly onNoDefault: OnNoDefault;
   private readonly parentContext?: Contexts;
-  readonly defaultLogLevel: number;
 
   constructor(
     configs: Config[] | Map<string, Config>,
     projectEnvId: ProjectEnvId,
     namespace: string | undefined,
     onNoDefault: OnNoDefault,
-    defaultLogLevel: number,
     contexts?: Contexts
   ) {
     this.config = Array.isArray(configs)
@@ -45,7 +32,6 @@ class Resolver implements PrefabInterface {
     this.namespace = namespace;
     this.onNoDefault = onNoDefault;
     this.parentContext = contexts;
-    this.defaultLogLevel = defaultLogLevel;
   }
 
   cloneWithContext(contexts: Contexts): Resolver {
@@ -54,7 +40,6 @@ class Resolver implements PrefabInterface {
       this.projectEnvId,
       this.namespace,
       this.onNoDefault,
-      this.defaultLogLevel,
       contexts
     );
   }
@@ -122,26 +107,6 @@ class Resolver implements PrefabInterface {
       `Expected boolean value for key ${key}, got ${typeof value}. Non-boolean FF's return \`false\` for isFeatureEnabled checks.`
     );
     return false;
-  }
-
-  shouldLog({
-    loggerName,
-    desiredLevel,
-    contexts,
-    defaultLogLevel,
-  }: {
-    loggerName: string;
-    desiredLevel: number | string;
-    defaultLogLevel?: number;
-    contexts?: Contexts;
-  }): boolean {
-    return shouldLog({
-      loggerName,
-      desiredLevel,
-      contexts,
-      defaultLevel: defaultLogLevel ?? this.defaultLogLevel,
-      resolver: this,
-    });
   }
 }
 


### PR DESCRIPTION
- Stronger typings
- Move log level string -> log level number coercion to boundary
- Fix issue with defaultLogLevel not being respected
