### PR TITLE
Telemetry: Context shape reporting

### DIFF
--- a/src/__tests__/telemetry/contextShapes.test.ts
+++ b/src/__tests__/telemetry/contextShapes.test.ts
@@ -1,0 +1,139 @@
+import { Prefab } from "../../prefab";
+import { contextShapes, stub } from "../../telemetry/contextShapes";
+import type { Contexts } from "../../types";
+import {
+  mockApiClient,
+  irrelevant,
+  projectEnvIdUnderTest,
+} from "../testHelpers";
+import basicConfig from "../fixtures/basicConfig";
+
+const userContext = new Map<string, any>([
+  ["key", "abc"],
+  ["email", "test@example.com"],
+  ["activated", true],
+  ["age", 12],
+  ["shoeSize", 11.5],
+  ["someArray", [1, 2, 3, 4]],
+]);
+
+const teamContext = new Map<string, any>([
+  ["key", "team-123"],
+  ["size", 9],
+]);
+
+describe("contextShapes", () => {
+  it("returns stub if contextUploadMode is not shapeOnly", () => {
+    expect(contextShapes(mockApiClient, "periodicExample")).toBe(stub);
+    expect(contextShapes(mockApiClient, "none")).toBe(stub);
+  });
+
+  it("pushes data", () => {
+    const aggregator = contextShapes(mockApiClient, "shapeOnly");
+
+    const contexts: Contexts = new Map([
+      ["user", userContext],
+      ["team", teamContext],
+    ]);
+
+    aggregator.push(contexts);
+
+    expect(Object.fromEntries(aggregator.data)).toStrictEqual({
+      team: {
+        key: 2,
+        size: 1,
+      },
+      user: {
+        key: 2,
+        email: 2,
+        activated: 5,
+        age: 1,
+        shoeSize: 4,
+        someArray: 10,
+      },
+    });
+  });
+
+  it("should sync context shapes to the server", async () => {
+    const aggregator = contextShapes(mockApiClient, "shapeOnly");
+
+    const contexts: Contexts = new Map([
+      ["user", userContext],
+      ["team", teamContext],
+    ]);
+
+    aggregator.push(contexts);
+
+    const syncResult = await aggregator.sync();
+
+    expect(mockApiClient.fetch).toHaveBeenCalled();
+
+    expect(syncResult).toStrictEqual({
+      status: 200,
+      dataSent: {
+        shapes: [
+          {
+            name: "user",
+            fieldTypes: {
+              key: 2,
+              email: 2,
+              activated: 5,
+              age: 1,
+              shoeSize: 4,
+              someArray: 10,
+            },
+          },
+          { name: "team", fieldTypes: { key: 2, size: 1 } },
+        ],
+      },
+    });
+
+    expect(aggregator.data).toStrictEqual(new Map());
+  });
+
+  describe("integration tests", () => {
+    const contexts = new Map([
+      [
+        "user",
+        new Map<string, any>([
+          ["key", "abc"],
+          ["randomNumber", 100],
+        ]),
+      ],
+    ]);
+
+    it("records context shapes when contextUploadMode=shapeOnly", () => {
+      const prefab = new Prefab({
+        apiKey: irrelevant,
+        contextUploadMode: "shapeOnly",
+      });
+      prefab.setConfig([basicConfig], projectEnvIdUnderTest);
+
+      prefab.get("basic.value", contexts);
+
+      expect(prefab.telemetry.contextShapes.data).toStrictEqual(
+        new Map(
+          Object.entries({
+            user: {
+              key: 2,
+              randomNumber: 1,
+            },
+          })
+        )
+      );
+    });
+
+    it("does not record context shapes by default", () => {
+      const prefabWithoutShapes = new Prefab({
+        apiKey: irrelevant,
+      });
+      prefabWithoutShapes.setConfig([basicConfig], projectEnvIdUnderTest);
+
+      prefabWithoutShapes.get("basic.value", contexts);
+
+      expect(prefabWithoutShapes.telemetry.contextShapes.data).toStrictEqual(
+        new Map()
+      );
+    });
+  });
+});

--- a/src/__tests__/telemetry/knownLoggers.test.ts
+++ b/src/__tests__/telemetry/knownLoggers.test.ts
@@ -1,24 +1,11 @@
 import Long from "long";
 import { knownLoggers, stub } from "../../telemetry/knownLoggers";
+import { mockApiClient } from "../testHelpers";
 
+// NOTE: Integration tests for this function are in the prefab.test.ts file.
 describe("knownLoggers", () => {
-  const mockApiClient = {
-    fetch: jest.fn(async () => ({
-      status: 200,
-      arrayBuffer: async (): Promise<ArrayBuffer> => {
-        return await Promise.resolve(new ArrayBuffer(0));
-      },
-    })),
-  };
-
-  it("should initialize a known logger with collectLoggerCounts set to false", () => {
-    const logger = knownLoggers(mockApiClient, "instanceHash", false);
-    expect(logger).toBe(stub);
-  });
-
-  it("should initialize a known logger with collectLoggerCounts set to true", () => {
-    const logger = knownLoggers(mockApiClient, "instanceHash", true);
-    expect(logger.data).toEqual({});
+  it("returns stub if collectLoggerCounts is false", () => {
+    expect(knownLoggers(mockApiClient, "instanceHash", false)).toBe(stub);
   });
 
   it("should push log entries to the logger", () => {

--- a/src/__tests__/testHelpers.ts
+++ b/src/__tests__/testHelpers.ts
@@ -39,3 +39,12 @@ export const levelAt = (path: string, level: string): Config => {
     draftId: irrelevantLong,
   };
 };
+
+export const mockApiClient = {
+  fetch: jest.fn(async () => ({
+    status: 200,
+    arrayBuffer: async (): Promise<ArrayBuffer> => {
+      return await Promise.resolve(new ArrayBuffer(0));
+    },
+  })),
+};

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -26,13 +26,15 @@ export const apiClient = (
     fetch: async ({ path, url, options }: InternalFetchArgs): FetchResult => {
       const opts = options ?? {};
 
+      const headers = makeHeaders(apiKey, {
+        ...(opts["headers"] ?? {}),
+        "Content-Type": "application/x-protobuf",
+        Accept: "application/x-protobuf",
+      });
+
       return await fetch(url ?? apiUrl + path, {
         ...opts,
-        headers: makeHeaders(apiKey, {
-          ...(opts["headers"] ?? {}),
-          "Content-Type": "application/x-protobuf",
-          Accept: "application/x-protobuf",
-        }),
+        headers,
       });
     },
   };

--- a/src/parseProto.ts
+++ b/src/parseProto.ts
@@ -16,9 +16,9 @@ export const decode = <T>(type: string, input: ArrayBuffer | string): T => {
   return root.lookupType("prefab." + type).decode(buffer) as T;
 };
 
-export const encode = <T>(type: string, data: any): T => {
+export const encode = (type: string, data: any): ArrayBuffer => {
   return root
     .lookupType("prefab." + type)
     .encode(data)
-    .finish() as T;
+    .finish();
 };

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,6 +1,6 @@
 import type { Config } from "./proto";
 import type { Context, Contexts, OnNoDefault, ProjectEnvId } from "./types";
-import type { PrefabInterface } from "./prefab";
+import type { PrefabInterface, Telemetry } from "./prefab";
 
 import { mergeContexts } from "./mergeContexts";
 
@@ -17,12 +17,14 @@ class Resolver implements PrefabInterface {
   private readonly namespace: string | undefined;
   private readonly onNoDefault: OnNoDefault;
   private readonly parentContext?: Contexts;
+  private readonly telemetry: Telemetry | undefined;
 
   constructor(
     configs: Config[] | Map<string, Config>,
     projectEnvId: ProjectEnvId,
     namespace: string | undefined,
     onNoDefault: OnNoDefault,
+    telemetry?: Telemetry,
     contexts?: Contexts
   ) {
     this.config = Array.isArray(configs)
@@ -32,6 +34,7 @@ class Resolver implements PrefabInterface {
     this.namespace = namespace;
     this.onNoDefault = onNoDefault;
     this.parentContext = contexts;
+    this.telemetry = telemetry;
   }
 
   cloneWithContext(contexts: Contexts): Resolver {
@@ -40,6 +43,7 @@ class Resolver implements PrefabInterface {
       this.projectEnvId,
       this.namespace,
       this.onNoDefault,
+      this.telemetry,
       contexts
     );
   }
@@ -82,6 +86,10 @@ class Resolver implements PrefabInterface {
       this.parentContext,
       contexts ?? emptyContexts
     );
+
+    if (this.telemetry !== undefined) {
+      this.telemetry.contextShapes.push(mergedContexts);
+    }
 
     return evaluate({
       config,

--- a/src/telemetry/contextShapes.ts
+++ b/src/telemetry/contextShapes.ts
@@ -1,0 +1,113 @@
+import type { ContextShape, ContextShapes } from "../proto";
+import type { Contexts } from "../types";
+import { encode } from "../parseProto";
+import type { ApiClient } from "../apiClient";
+import type { ContextUploadMode, SyncResult, Telemetry } from "./types";
+
+const ENDPOINT = "/api/v1/context-shapes";
+
+type ContextShapeTelemetry = Telemetry & {
+  data: Map<string, Record<string, number>>;
+  push: (contexts: Contexts) => void;
+};
+
+export const stub: ContextShapeTelemetry = {
+  enabled: false,
+  sync: async () => undefined,
+  timeout: undefined,
+  data: new Map<string, Record<string, number>>(),
+  push() {},
+};
+
+export const fieldTypeForValue = (value: unknown): number => {
+  if (Number.isInteger(value)) {
+    return 1;
+  }
+
+  if (typeof value === "number") {
+    return 4;
+  }
+
+  if (typeof value === "boolean") {
+    return 5;
+  }
+
+  if (Array.isArray(value)) {
+    return 10;
+  }
+
+  return 2;
+};
+
+export const contextShapes = (
+  apiClient: ApiClient,
+  contextUploadMode: ContextUploadMode,
+  namespace?: string
+): ContextShapeTelemetry => {
+  if (contextUploadMode !== "shapeOnly") {
+    return stub;
+  }
+
+  const data = new Map<string, Record<string, number>>();
+
+  return {
+    enabled: true,
+
+    data,
+
+    timeout: undefined,
+
+    push(contexts: Contexts) {
+      contexts.forEach((context, name) => {
+        context.forEach((value, key) => {
+          const shape = data.get(name) ?? {};
+
+          if (shape[key] === undefined) {
+            shape[key] = fieldTypeForValue(value);
+            data.set(name, shape);
+          }
+        });
+      });
+    },
+
+    async sync(): Promise<SyncResult | undefined> {
+      if (data.size === 0) {
+        return;
+      }
+
+      const shapes: ContextShape[] = [];
+
+      data.forEach((shape, name) => {
+        shapes.push({
+          name,
+          fieldTypes: shape,
+        });
+
+        data.delete(name);
+      });
+
+      const apiData: ContextShapes = {
+        shapes,
+      };
+
+      if (namespace !== undefined) {
+        apiData.namespace = namespace;
+      }
+
+      const body = encode("ContextShapes", apiData);
+
+      const result = await apiClient.fetch({
+        path: ENDPOINT,
+        options: {
+          method: "POST",
+          body,
+        },
+      });
+
+      return {
+        status: result.status,
+        dataSent: apiData,
+      };
+    },
+  };
+};

--- a/src/telemetry/knownLoggers.ts
+++ b/src/telemetry/knownLoggers.ts
@@ -3,20 +3,8 @@ import type { Logger, Loggers } from "../proto";
 import type { ApiClient } from "../apiClient";
 import { encode } from "../parseProto";
 import type { ValidLogLevelName } from "../logger";
-import { type SyncResult, type Telemetry, now } from "./reporter";
-
-type Pluralize<S extends string> = `${S}s`;
-
-export type LoggerLevelName = Pluralize<ValidLogLevelName>;
-
-const NUMBER_LEVEL_LOOKUP: Record<string, LoggerLevelName> = {
-  1: "traces",
-  2: "debugs",
-  3: "infos",
-  5: "warns",
-  6: "errors",
-  9: "fatals",
-};
+import { now } from "./reporter";
+import type { SyncResult, Telemetry } from "./types";
 
 const ENDPOINT = "/api/v1/known-loggers";
 
@@ -31,6 +19,19 @@ export const stub: KnownLogger = {
   push() {},
   sync: async () => undefined,
   timeout: undefined,
+};
+
+type Pluralize<S extends string> = `${S}s`;
+
+export type LoggerLevelName = Pluralize<ValidLogLevelName>;
+
+const NUMBER_LEVEL_LOOKUP: Record<string, LoggerLevelName> = {
+  1: "traces",
+  2: "debugs",
+  3: "infos",
+  5: "warns",
+  6: "errors",
+  9: "fatals",
 };
 
 export const knownLoggers = (
@@ -66,7 +67,6 @@ export const knownLoggers = (
 
     async sync(): Promise<SyncResult | undefined> {
       if (Object.keys(data).length === 0) {
-        await Promise.resolve(undefined);
         return;
       }
 
@@ -105,7 +105,7 @@ export const knownLoggers = (
         path: ENDPOINT,
         options: {
           method: "POST",
-          body: encode<Loggers>("Loggers", apiData),
+          body: encode("Loggers", apiData),
         },
       });
 

--- a/src/telemetry/reporter.ts
+++ b/src/telemetry/reporter.ts
@@ -1,16 +1,6 @@
 import Long from "long";
 import { Backoff } from "./backoff";
-
-export interface SyncResult {
-  status: number;
-  dataSent: any;
-}
-
-export interface Telemetry {
-  sync: () => Promise<SyncResult | undefined>;
-  enabled: boolean;
-  timeout: NodeJS.Timeout | undefined;
-}
+import type { Telemetry } from "./types";
 
 export const now = (): Long => Long.fromNumber(Date.now());
 
@@ -27,9 +17,9 @@ const syncTelemetry = (telemetry: Telemetry, backoff: Backoff): void => {
 export const TelemetryReporter = {
   start(telemetries: Telemetry[]): void {
     telemetries.forEach((telemetry) => {
-      const backoff = new Backoff({ maxDelay: 600, initialDelay: 8 });
-
       if (telemetry.enabled) {
+        const backoff = new Backoff({ maxDelay: 600, initialDelay: 8 });
+
         syncTelemetry(telemetry, backoff);
       }
     });

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,0 +1,12 @@
+export interface SyncResult {
+  status: number;
+  dataSent: any;
+}
+
+export interface Telemetry {
+  sync: () => Promise<SyncResult | undefined>;
+  enabled: boolean;
+  timeout: NodeJS.Timeout | undefined;
+}
+
+export type ContextUploadMode = "periodicExample" | "shapeOnly" | "none";

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,13 @@ import type Long from "long";
 
 export type ContextValue = string | number | boolean | undefined;
 
-export type Context = Map<string, ContextValue>;
+type ContextName = string;
 
-export type Contexts = Map<string, Context>;
+type ContextKey = string;
+
+export type Context = Map<ContextKey, ContextValue>;
+
+export type Contexts = Map<ContextName, Context>;
 
 export type ProjectEnvId = Long;
 


### PR DESCRIPTION
Not enabled by default, but you can opt-in with `contextUploadMode:
"shapeOnly"`

This telemetry data is used to populate the property dropdown in the
Prefab rule builder.
