### PR TITLE
Telemetry: Example Contexts reporting

### DIFF
--- a/src/__tests__/evaluate.test.ts
+++ b/src/__tests__/evaluate.test.ts
@@ -22,7 +22,7 @@ const emptyResolver = new Resolver(
   "error"
 );
 
-describe.only("evaluate", () => {
+describe("evaluate", () => {
   it("returns a config value with no rules", () => {
     expect(
       evaluate({

--- a/src/__tests__/prefab.test.ts
+++ b/src/__tests__/prefab.test.ts
@@ -45,6 +45,7 @@ describe("prefab", () => {
       const prefab = new Prefab({
         apiKey: validApiKey,
         collectLoggerCounts: false,
+        contextUploadMode: "none",
       });
       await prefab.init();
 

--- a/src/__tests__/telemetry/contextShapes.test.ts
+++ b/src/__tests__/telemetry/contextShapes.test.ts
@@ -22,6 +22,11 @@ const teamContext = new Map<string, any>([
   ["size", 9],
 ]);
 
+const contexts: Contexts = new Map([
+  ["user", userContext],
+  ["team", teamContext],
+]);
+
 describe("contextShapes", () => {
   it("returns stub if contextUploadMode is not shapeOnly", () => {
     expect(contextShapes(mockApiClient, "periodicExample")).toBe(stub);
@@ -30,11 +35,6 @@ describe("contextShapes", () => {
 
   it("pushes data", () => {
     const aggregator = contextShapes(mockApiClient, "shapeOnly");
-
-    const contexts: Contexts = new Map([
-      ["user", userContext],
-      ["team", teamContext],
-    ]);
 
     aggregator.push(contexts);
 
@@ -56,11 +56,6 @@ describe("contextShapes", () => {
 
   it("should sync context shapes to the server", async () => {
     const aggregator = contextShapes(mockApiClient, "shapeOnly");
-
-    const contexts: Contexts = new Map([
-      ["user", userContext],
-      ["team", teamContext],
-    ]);
 
     aggregator.push(contexts);
 

--- a/src/__tests__/telemetry/exampleContexts.test.ts
+++ b/src/__tests__/telemetry/exampleContexts.test.ts
@@ -1,0 +1,193 @@
+import Long from "long";
+
+import { Prefab } from "../../prefab";
+import { exampleContexts, stub } from "../../telemetry/exampleContexts";
+import type { Contexts } from "../../types";
+import {
+  mockApiClient,
+  irrelevant,
+  projectEnvIdUnderTest,
+} from "../testHelpers";
+import basicConfig from "../fixtures/basicConfig";
+
+const instanceHash = "instance-hash";
+
+const userContext = new Map<string, any>([
+  ["key", "abc"],
+  ["email", "test@example.com"],
+  ["activated", true],
+  ["age", 12],
+  ["shoeSize", 11.5],
+  ["someArray", [1, 2, 3, 4]],
+]);
+
+const teamContext = new Map<string, any>([
+  ["key", "team-123"],
+  ["size", 9],
+]);
+
+const contexts: Contexts = new Map([
+  ["user", userContext],
+  ["team", teamContext],
+]);
+
+describe("exampleContexts", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it("returns a stub if contextUploadMode is not periodicExample", () => {
+    expect(exampleContexts(mockApiClient, instanceHash, "shapeOnly")).toBe(
+      stub
+    );
+    expect(exampleContexts(mockApiClient, instanceHash, "none")).toBe(stub);
+  });
+
+  it("pushes data", () => {
+    const initialTime = Date.now();
+
+    const aggregator = exampleContexts(
+      mockApiClient,
+      instanceHash,
+      "periodicExample"
+    );
+
+    const otherContexts: Contexts = new Map([
+      ["user", new Map([["key", "def"]])],
+    ]);
+
+    aggregator.push(contexts);
+
+    // The second push won't matter because we've cached this key for an hour
+    aggregator.push(contexts);
+
+    // But a context with a different key will be pushed
+    aggregator.push(otherContexts);
+
+    expect(aggregator.data).toStrictEqual([
+      [initialTime, contexts],
+      [initialTime, otherContexts],
+    ]);
+
+    // after some time passes, we can push again
+    jest.advanceTimersByTime(60 * 60 * 1000 + 1);
+
+    aggregator.push(contexts);
+
+    expect(aggregator.data).toStrictEqual([
+      [initialTime, contexts],
+      [initialTime, otherContexts],
+      [Date.now(), contexts],
+    ]);
+  });
+
+  it("should sync to the server", async () => {
+    const aggregator = exampleContexts(
+      mockApiClient,
+      instanceHash,
+      "periodicExample"
+    );
+
+    if (!aggregator.enabled || aggregator.cache === undefined) {
+      throw new Error("aggregator is not enabled");
+    }
+
+    aggregator.cache.prune = jest.fn();
+
+    aggregator.push(contexts);
+
+    const syncResult = await aggregator.sync();
+
+    expect(mockApiClient.fetch).toHaveBeenCalled();
+
+    expect(syncResult?.status).toEqual(200);
+
+    expect(syncResult?.dataSent).toStrictEqual({
+      instanceHash: "instance-hash",
+      events: [
+        {
+          exampleContexts: {
+            examples: [
+              {
+                timestamp: new Long(Date.now()),
+                contextSet: {
+                  contexts: [
+                    {
+                      type: "user",
+                      values: {
+                        key: {
+                          string: "abc",
+                        },
+                        email: {
+                          string: "test@example.com",
+                        },
+                        activated: {
+                          bool: true,
+                        },
+                        age: {
+                          int: 12,
+                        },
+                        shoeSize: {
+                          double: 11.5,
+                        },
+                        someArray: {
+                          stringList: [1, 2, 3, 4],
+                        },
+                      },
+                    },
+                    {
+                      type: "team",
+                      values: {
+                        key: {
+                          string: "team-123",
+                        },
+                        size: {
+                          int: 9,
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(aggregator.data).toStrictEqual([]);
+
+    expect(aggregator.cache.prune).toHaveBeenCalled();
+  });
+
+  describe("integration tests", () => {
+    it("records context examples by default", () => {
+      const prefab = new Prefab({
+        apiKey: irrelevant,
+      });
+      prefab.setConfig([basicConfig], projectEnvIdUnderTest);
+
+      prefab.get("basic.value", contexts);
+
+      expect(prefab.telemetry.exampleContexts.data).toStrictEqual([
+        [Date.now(), contexts],
+      ]);
+    });
+
+    it("does not record context examples when contextUploadMode is not periodicExample", () => {
+      const prefab = new Prefab({
+        apiKey: irrelevant,
+        contextUploadMode: "none",
+      });
+      prefab.setConfig([basicConfig], projectEnvIdUnderTest);
+
+      prefab.get("basic.value", contexts);
+
+      expect(prefab.telemetry.exampleContexts.data).toStrictEqual([]);
+    });
+  });
+});

--- a/src/__tests__/telemetry/rateLimitCache.test.ts
+++ b/src/__tests__/telemetry/rateLimitCache.test.ts
@@ -1,0 +1,54 @@
+import { rateLimitCache } from "../../telemetry/rateLimitCache";
+
+describe("rateLimitCache", () => {
+  const duration = 1000;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it("should return false for non-existent key", () => {
+    const cache = rateLimitCache(duration);
+    expect(cache.isFresh("nonexistent")).toBe(false);
+  });
+
+  it("should return true for a fresh key", () => {
+    const cache = rateLimitCache(duration);
+    cache.set("freshKey");
+    expect(cache.isFresh("freshKey")).toBe(true);
+  });
+
+  it("should return false for an expired key", () => {
+    const cache = rateLimitCache(duration);
+    cache.set("expiredKey");
+    jest.advanceTimersByTime(duration + 1);
+    expect(cache.isFresh("expiredKey")).toBe(false);
+  });
+
+  it("should prune expired entries", () => {
+    const cache = rateLimitCache(duration);
+    cache.set("key1");
+    cache.set("key2");
+
+    jest.advanceTimersByTime(duration + 1);
+    cache.prune();
+
+    expect(cache.isFresh("key1")).toBe(false);
+    expect(cache.isFresh("key2")).toBe(false);
+  });
+
+  it("should not prune fresh entries", () => {
+    const cache = rateLimitCache(duration);
+    cache.set("freshKey1");
+    cache.set("freshKey2");
+
+    cache.prune();
+
+    expect(cache.isFresh("freshKey1")).toBe(true);
+    expect(cache.isFresh("freshKey2")).toBe(true);
+  });
+});

--- a/src/__tests__/wrap.test.ts
+++ b/src/__tests__/wrap.test.ts
@@ -1,0 +1,43 @@
+import { valueType, wrap } from "../wrap"; // Update with the correct path to your module
+
+describe("valueType", () => {
+  it('should return "int" for integer values', () => {
+    expect(valueType(42)).toBe("int");
+    expect(valueType(-10)).toBe("int");
+    expect(valueType(0)).toBe("int");
+  });
+
+  it('should return "double" for decimal number values', () => {
+    expect(valueType(3.14)).toBe("double");
+    expect(valueType(-0.5)).toBe("double");
+  });
+
+  it('should return "bool" for boolean values', () => {
+    expect(valueType(true)).toBe("bool");
+    expect(valueType(false)).toBe("bool");
+  });
+
+  it('should return "stringList" for array values', () => {
+    expect(valueType(["apple", "banana"])).toBe("stringList");
+    expect(valueType([])).toBe("stringList");
+  });
+
+  it('should return "string" for other values', () => {
+    expect(valueType("hello")).toBe("string");
+    expect(valueType({})).toBe("string");
+    expect(valueType(null)).toBe("string");
+    expect(valueType(undefined)).toBe("string");
+  });
+});
+
+describe("wrap", () => {
+  it("should wrap values with the appropriate key", () => {
+    expect(wrap(42)).toEqual({ int: 42 });
+    expect(wrap(3.14)).toEqual({ double: 3.14 });
+    expect(wrap(true)).toEqual({ bool: true });
+    expect(wrap(["apple", "banana"])).toEqual({
+      stringList: ["apple", "banana"],
+    });
+    expect(wrap("hello")).toEqual({ string: "hello" });
+  });
+});

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -16,6 +16,7 @@ import { TelemetryReporter } from "./telemetry/reporter";
 import type { ContextUploadMode } from "./telemetry/types";
 import { knownLoggers } from "./telemetry/knownLoggers";
 import { contextShapes } from "./telemetry/contextShapes";
+import { exampleContexts } from "./telemetry/exampleContexts";
 
 const DEFAULT_POLL_INTERVAL = 60 * 1000;
 const PREFAB_DEFAULT_LOG_LEVEL = LogLevel.WARN;
@@ -36,6 +37,7 @@ export interface PrefabInterface {
 export interface Telemetry {
   knownLoggers: ReturnType<typeof knownLoggers>;
   contextShapes: ReturnType<typeof contextShapes>;
+  exampleContexts: ReturnType<typeof exampleContexts>;
 }
 
 interface ConstructorProps {
@@ -115,6 +117,11 @@ class Prefab implements PrefabInterface {
         this.namespace
       ),
       contextShapes: contextShapes(this.apiClient, contextUploadMode),
+      exampleContexts: exampleContexts(
+        this.apiClient,
+        this.instanceHash,
+        contextUploadMode
+      ),
     };
   }
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -89,6 +89,7 @@ class Resolver implements PrefabInterface {
 
     if (this.telemetry !== undefined) {
       this.telemetry.contextShapes.push(mergedContexts);
+      this.telemetry.exampleContexts.push(mergedContexts);
     }
 
     return evaluate({

--- a/src/telemetry/exampleContexts.ts
+++ b/src/telemetry/exampleContexts.ts
@@ -1,0 +1,136 @@
+import Long from "long";
+import type { ContextUploadMode, SyncResult, Telemetry } from "./types";
+import type { ApiClient } from "../apiClient";
+import type { Contexts } from "../types";
+import { rateLimitCache } from "./rateLimitCache";
+import { encode } from "../parseProto";
+import type {
+  ConfigValue,
+  Context,
+  ExampleContext,
+  TelemetryEvent,
+  TelemetryEvents,
+} from "../proto";
+import { wrap } from "../wrap";
+
+const ENDPOINT = "/api/v1/telemetry";
+
+type SeenContext = [number, Contexts];
+
+type ExampleContextsTelemetry = Telemetry & {
+  data: SeenContext[];
+  push: (contexts: Contexts) => void;
+  cache?: ReturnType<typeof rateLimitCache>;
+};
+
+export const stub: ExampleContextsTelemetry = {
+  enabled: false,
+  sync: async () => undefined,
+  timeout: undefined,
+  data: [],
+  push: () => {},
+};
+
+const groupedKey = (contexts: Contexts): string => {
+  return Array.from(contexts.values())
+    .map((context) => {
+      const key = context.get("key");
+      return typeof key === "string" ? key : JSON.stringify(key);
+    })
+    .sort()
+    .join("|");
+};
+
+const contextsToProto = (contexts: Contexts): Context[] => {
+  return Array.from(contexts.entries()).map(([key, context]) => {
+    const valueProtos: Record<string, ConfigValue> = {};
+
+    Array.from(context.entries()).forEach(([key, value]) => {
+      valueProtos[key] = wrap(value);
+    });
+
+    const contextProto: Context = {
+      type: key,
+      values: valueProtos,
+    };
+
+    return contextProto;
+  });
+};
+
+export const exampleContexts = (
+  apiClient: ApiClient,
+  instanceHash: string,
+  contextUploadMode: ContextUploadMode
+): ExampleContextsTelemetry => {
+  if (contextUploadMode !== "periodicExample") {
+    return stub;
+  }
+
+  const cache = rateLimitCache(60 * 60 * 1000);
+
+  const data: SeenContext[] = [];
+
+  return {
+    enabled: true,
+
+    data,
+
+    timeout: undefined,
+
+    cache,
+
+    push(contexts: Contexts) {
+      const key = groupedKey(contexts);
+
+      if (!cache.isFresh(key)) {
+        data.push([Date.now(), contexts]);
+        cache.set(key);
+      }
+    },
+
+    async sync(): Promise<SyncResult | undefined> {
+      if (data.length === 0) {
+        return undefined;
+      }
+
+      const examples: ExampleContext[] = data.map(([timestamp, contexts]) => {
+        return {
+          timestamp: new Long(timestamp),
+          contextSet: {
+            contexts: contextsToProto(contexts),
+          },
+        };
+      });
+
+      data.length = 0;
+      cache.prune();
+
+      const event: TelemetryEvent = {
+        exampleContexts: {
+          examples,
+        },
+      };
+
+      const apiData: TelemetryEvents = {
+        instanceHash,
+        events: [event],
+      };
+
+      const body = encode("TelemetryEvents", apiData);
+
+      const result = await apiClient.fetch({
+        path: ENDPOINT,
+        options: {
+          method: "POST",
+          body,
+        },
+      });
+
+      return {
+        status: result.status,
+        dataSent: apiData,
+      };
+    },
+  };
+};

--- a/src/telemetry/rateLimitCache.ts
+++ b/src/telemetry/rateLimitCache.ts
@@ -1,0 +1,35 @@
+interface RateLimitCache {
+  isFresh: (key: string) => boolean;
+  set: (key: string) => void;
+  prune: () => void;
+}
+
+export const rateLimitCache = (duration: number): RateLimitCache => {
+  const data = new Map<string, number>();
+
+  return {
+    isFresh(key: string) {
+      const timestamp = data.get(key);
+
+      if (timestamp === undefined) {
+        return false;
+      }
+
+      return Date.now() - timestamp <= duration;
+    },
+
+    set(key: string) {
+      data.set(key, Date.now());
+    },
+
+    prune() {
+      const now = Date.now();
+
+      for (const [key, timestamp] of data.entries()) {
+        if (now - timestamp > duration) {
+          data.delete(key);
+        }
+      }
+    },
+  };
+};

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -1,0 +1,29 @@
+import type { ConfigValue } from "./proto";
+
+type ConfigValueKey = keyof ConfigValue;
+
+export const valueType = (value: unknown): ConfigValueKey => {
+  if (Number.isInteger(value)) {
+    return "int";
+  }
+
+  if (typeof value === "number") {
+    return "double";
+  }
+
+  if (typeof value === "boolean") {
+    return "bool";
+  }
+
+  if (Array.isArray(value)) {
+    return "stringList";
+  }
+
+  return "string";
+};
+
+export const wrap = (value: unknown): Record<string, ConfigValue> => {
+  return {
+    [valueType(value)]: value as ConfigValue,
+  };
+};


### PR DESCRIPTION
Enabled by default, but you can opt-out by setting `contextUploadMode`
to `shapeOnly` or `none`.

This telemetry data is used to populate the Contexts section of the
Prefab UI where you can easily override variants for your users.
