### PR TITLE
Telemetry: Evaluation summary reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint --cache=true --ext .ts .",
     "prep": "npm run lint && npm run format && npm run test && npm run build",
     "regen-proto": "npx pbjs -t json ../prefab-cloud/prefab.proto > src/proto.json && protoc --ts_proto_opt=esModuleInterop=true --ts_proto_opt=forceLong=long --ts_proto_opt=onlyTypes=true --ts_proto_opt=env=node --ts_proto_out=./ -I ../prefab-cloud/ prefab.proto && mv prefab.ts src/proto.ts",
-    "test": "jest",
+    "test": "jest --forceExit",
     "prepare": "husky install"
   },
   "keywords": [],

--- a/src/__tests__/evaluate.test.ts
+++ b/src/__tests__/evaluate.test.ts
@@ -1,3 +1,4 @@
+import Long from "long";
 import basicConfig from "./fixtures/basicConfig";
 import basicLogLevel from "./fixtures/basicLogLevel";
 import envConfig from "./fixtures/envConfig";
@@ -7,8 +8,10 @@ import propEndsWithOneOf from "./fixtures/propEndsWithOneOf";
 import propIsNotOneOf from "./fixtures/propIsNotOneOf";
 import propIsOneOf from "./fixtures/propIsOneOf";
 import propIsOneOfAndEndsWith from "./fixtures/propIsOneOfAndEndsWith";
+import rolloutFlag from "./fixtures/rolloutFlag";
 import { Resolver } from "../resolver";
 import type { EvaluateArgs } from "../evaluate";
+import type { Contexts } from "../types";
 import { evaluate } from "../evaluate";
 import { emptyContexts, projectEnvIdUnderTest } from "./testHelpers";
 
@@ -22,8 +25,38 @@ const emptyResolver = new Resolver(
   "error"
 );
 
+const usContexts = new Map([
+  [
+    "user",
+    new Map([
+      ["trackingId", "abc"],
+      ["country", "US"],
+    ]),
+  ],
+]);
+const ukContexts = new Map([
+  [
+    "user",
+    new Map([
+      ["trackingId", "123"],
+      ["country", "UK"],
+    ]),
+  ],
+]);
+const frContexts = new Map([["user", new Map([["country", "FR"]])]]);
+
+const prefabEmailContexts = new Map([
+  ["user", new Map([["email", "@prefab.cloud"]])],
+]);
+const exampleEmailContexts = new Map([
+  ["user", new Map([["email", "@example.com"]])],
+]);
+const hotmailEmailContexts = new Map([
+  ["user", new Map([["email", "@hotmail.com"]])],
+]);
+
 describe("evaluate", () => {
-  it("returns a config value with no rules", () => {
+  it("returns an evaluation with no rules", () => {
     expect(
       evaluate({
         config: basicConfig,
@@ -32,7 +65,16 @@ describe("evaluate", () => {
         contexts: emptyContexts,
         resolver: emptyResolver,
       })
-    ).toEqual(42);
+    ).toStrictEqual({
+      configId: basicConfig.id,
+      configKey: basicConfig.key,
+      configType: basicConfig.configType,
+      configRowIndex: 0,
+      unwrappedValue: 42,
+      conditionalValueIndex: 0,
+      selectedValue: { int: new Long(42) },
+      weightedValueIndex: undefined,
+    });
   });
 
   it("returns a config logLevel value with no rules", () => {
@@ -44,10 +86,19 @@ describe("evaluate", () => {
         contexts: emptyContexts,
         resolver: emptyResolver,
       })
-    ).toEqual(3);
+    ).toStrictEqual({
+      configId: basicLogLevel.id,
+      configKey: basicLogLevel.key,
+      configType: basicLogLevel.configType,
+      configRowIndex: 0,
+      conditionalValueIndex: 0,
+      unwrappedValue: 3,
+      selectedValue: { logLevel: 3 },
+      weightedValueIndex: undefined,
+    });
   });
 
-  it("returns a config value with no rules but an environment", () => {
+  it("returns an evaluation with no rules but an environment", () => {
     expect(
       evaluate({
         config: envConfig,
@@ -56,10 +107,67 @@ describe("evaluate", () => {
         contexts: emptyContexts,
         resolver: emptyResolver,
       })
-    ).toEqual(["a", "b", "c", "d"]);
+    ).toStrictEqual({
+      configId: envConfig.id,
+      configKey: envConfig.key,
+      configType: envConfig.configType,
+      configRowIndex: 0,
+      unwrappedValue: ["a", "b", "c", "d"],
+      conditionalValueIndex: 0,
+      selectedValue: { stringList: { values: ["a", "b", "c", "d"] } },
+      weightedValueIndex: undefined,
+    });
   });
 
-  it("returns a config value for a namespace", () => {
+  it("returns an evaluation for a rollout", () => {
+    const args = (contexts: Contexts): EvaluateArgs => ({
+      config: rolloutFlag,
+      namespace: undefined,
+      projectEnvId: projectEnvIdUnderTest,
+      contexts,
+      resolver: emptyResolver,
+    });
+
+    expect(evaluate(args(ukContexts))).toStrictEqual({
+      configId: rolloutFlag.id,
+      configKey: rolloutFlag.key,
+      conditionalValueIndex: 0,
+      configRowIndex: 0,
+      configType: 2,
+      selectedValue: {
+        weightedValues: {
+          hashByPropertyName: "user.trackingId",
+          weightedValues: [
+            { value: { bool: false }, weight: 90 },
+            { value: { bool: true }, weight: 10 },
+          ],
+        },
+      },
+      unwrappedValue: true,
+      weightedValueIndex: 1,
+    });
+
+    expect(evaluate(args(usContexts))).toStrictEqual({
+      configId: rolloutFlag.id,
+      configKey: rolloutFlag.key,
+      conditionalValueIndex: 0,
+      configRowIndex: 0,
+      configType: 2,
+      selectedValue: {
+        weightedValues: {
+          hashByPropertyName: "user.trackingId",
+          weightedValues: [
+            { value: { bool: false }, weight: 90 },
+            { value: { bool: true }, weight: 10 },
+          ],
+        },
+      },
+      unwrappedValue: false,
+      weightedValueIndex: 0,
+    });
+  });
+
+  it("returns an evaluation for a namespace", () => {
     const args = (namespace: string | undefined): EvaluateArgs => ({
       config: namespaceConfig,
       projectEnvId: projectEnvIdUnderTest,
@@ -68,12 +176,52 @@ describe("evaluate", () => {
       resolver: emptyResolver,
     });
 
-    expect(evaluate(args("my-namespace"))).toEqual(["in-namespace"]);
-    expect(evaluate(args("incorrect"))).toEqual(["not-in-namespace"]);
-    expect(evaluate(args(noNamespace))).toEqual(["not-in-namespace"]);
+    expect(evaluate(args("my-namespace"))).toStrictEqual({
+      configId: namespaceConfig.id,
+      configType: namespaceConfig.configType,
+      configKey: namespaceConfig.key,
+      unwrappedValue: ["in-namespace"],
+      configRowIndex: 0,
+      conditionalValueIndex: 1,
+      selectedValue: { stringList: { values: ["in-namespace"] } },
+      weightedValueIndex: undefined,
+    });
+
+    expect(evaluate(args("wrong-namespace"))).toStrictEqual({
+      configId: namespaceConfig.id,
+      configKey: namespaceConfig.key,
+      configType: namespaceConfig.configType,
+      unwrappedValue: ["wrong-namespace"],
+      configRowIndex: 0,
+      conditionalValueIndex: 0,
+      selectedValue: { stringList: { values: ["wrong-namespace"] } },
+      weightedValueIndex: undefined,
+    });
+
+    expect(evaluate(args("incorrect"))).toStrictEqual({
+      configId: namespaceConfig.id,
+      configKey: namespaceConfig.key,
+      configType: namespaceConfig.configType,
+      unwrappedValue: ["not-in-namespace"],
+      configRowIndex: 0,
+      conditionalValueIndex: 2,
+      selectedValue: { stringList: { values: ["not-in-namespace"] } },
+      weightedValueIndex: undefined,
+    });
+
+    expect(evaluate(args(noNamespace))).toEqual({
+      configId: namespaceConfig.id,
+      configKey: namespaceConfig.key,
+      configType: namespaceConfig.configType,
+      unwrappedValue: ["not-in-namespace"],
+      configRowIndex: 0,
+      conditionalValueIndex: 2,
+      selectedValue: { stringList: { values: ["not-in-namespace"] } },
+      weightedValueIndex: undefined,
+    });
   });
 
-  it("returns a config value for a PROP_IS_ONE_OF match", () => {
+  it("returns an evaluation for a PROP_IS_ONE_OF match", () => {
     const args = (
       contexts: Map<string, Map<string, string>>
     ): EvaluateArgs => ({
@@ -84,22 +232,52 @@ describe("evaluate", () => {
       resolver: emptyResolver,
     });
 
-    expect(evaluate(args(emptyContexts))).toEqual("default");
+    expect(evaluate(args(emptyContexts))).toStrictEqual({
+      configId: propIsOneOf.id,
+      configKey: propIsOneOf.key,
+      configType: propIsOneOf.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["country", "US"]])]])))
-    ).toEqual("correct");
+    expect(evaluate(args(usContexts))).toStrictEqual({
+      configId: propIsOneOf.id,
+      configKey: propIsOneOf.key,
+      configType: propIsOneOf.configType,
+      unwrappedValue: "correct",
+      configRowIndex: 0,
+      selectedValue: { string: "correct" },
+      conditionalValueIndex: 0,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["country", "UK"]])]])))
-    ).toEqual("correct");
+    expect(evaluate(args(ukContexts))).toStrictEqual({
+      configId: propIsOneOf.id,
+      configKey: propIsOneOf.key,
+      configType: propIsOneOf.configType,
+      unwrappedValue: "correct",
+      configRowIndex: 0,
+      selectedValue: { string: "correct" },
+      conditionalValueIndex: 0,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["country", "FR"]])]])))
-    ).toEqual("default");
+    expect(evaluate(args(frContexts))).toStrictEqual({
+      configId: propIsOneOf.id,
+      configKey: propIsOneOf.key,
+      configType: propIsOneOf.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
   });
 
-  it("returns a config value for a PROP_IS_NOT_ONE_OF match", () => {
+  it("returns an evaluation for a PROP_IS_NOT_ONE_OF match", () => {
     const args = (
       contexts: Map<string, Map<string, string>>
     ): EvaluateArgs => ({
@@ -110,22 +288,52 @@ describe("evaluate", () => {
       resolver: emptyResolver,
     });
 
-    expect(evaluate(args(emptyContexts))).toEqual("correct");
+    expect(evaluate(args(emptyContexts))).toStrictEqual({
+      configId: propIsNotOneOf.id,
+      configKey: propIsNotOneOf.key,
+      configType: propIsNotOneOf.configType,
+      unwrappedValue: "correct",
+      configRowIndex: 0,
+      selectedValue: { string: "correct" },
+      conditionalValueIndex: 0,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["country", "US"]])]])))
-    ).toEqual("default");
+    expect(evaluate(args(usContexts))).toStrictEqual({
+      configId: propIsNotOneOf.id,
+      configKey: propIsNotOneOf.key,
+      configType: propIsNotOneOf.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["country", "UK"]])]])))
-    ).toEqual("default");
+    expect(evaluate(args(ukContexts))).toStrictEqual({
+      configId: propIsNotOneOf.id,
+      configKey: propIsNotOneOf.key,
+      configType: propIsNotOneOf.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["country", "FR"]])]])))
-    ).toEqual("correct");
+    expect(evaluate(args(frContexts))).toStrictEqual({
+      configId: propIsNotOneOf.id,
+      configKey: propIsNotOneOf.key,
+      configType: propIsNotOneOf.configType,
+      configRowIndex: 0,
+      unwrappedValue: "correct",
+      selectedValue: { string: "correct" },
+      conditionalValueIndex: 0,
+      weightedValueIndex: undefined,
+    });
   });
 
-  it("returns a config value for a PROP_ENDS_WITH_ONE_OF match", () => {
+  it("returns an evaluation for a PROP_ENDS_WITH_ONE_OF match", () => {
     const args = (
       contexts: Map<string, Map<string, string>>
     ): EvaluateArgs => ({
@@ -136,22 +344,52 @@ describe("evaluate", () => {
       resolver: emptyResolver,
     });
 
-    expect(evaluate(args(emptyContexts))).toEqual("default");
+    expect(evaluate(args(emptyContexts))).toStrictEqual({
+      configId: propEndsWithOneOf.id,
+      configKey: propEndsWithOneOf.key,
+      configType: propEndsWithOneOf.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["email", "@prefab.cloud"]])]])))
-    ).toEqual("correct");
+    expect(evaluate(args(prefabEmailContexts))).toStrictEqual({
+      configId: propEndsWithOneOf.id,
+      configKey: propEndsWithOneOf.key,
+      configType: propEndsWithOneOf.configType,
+      unwrappedValue: "correct",
+      configRowIndex: 0,
+      selectedValue: { string: "correct" },
+      conditionalValueIndex: 0,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["email", "@example.com"]])]])))
-    ).toEqual("correct");
+    expect(evaluate(args(exampleEmailContexts))).toStrictEqual({
+      configId: propEndsWithOneOf.id,
+      configKey: propEndsWithOneOf.key,
+      configType: propEndsWithOneOf.configType,
+      unwrappedValue: "correct",
+      configRowIndex: 0,
+      selectedValue: { string: "correct" },
+      conditionalValueIndex: 0,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["email", "@hotmail.com"]])]])))
-    ).toEqual("default");
+    expect(evaluate(args(hotmailEmailContexts))).toStrictEqual({
+      configId: propEndsWithOneOf.id,
+      configKey: propEndsWithOneOf.key,
+      configType: propEndsWithOneOf.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
   });
 
-  it("returns a config value for a PROP_DOES_NOT_END_WITH_ONE_OF  match", () => {
+  it("returns an evaluation for a PROP_DOES_NOT_END_WITH_ONE_OF match", () => {
     const args = (
       contexts: Map<string, Map<string, string>>
     ): EvaluateArgs => ({
@@ -162,22 +400,52 @@ describe("evaluate", () => {
       resolver: emptyResolver,
     });
 
-    expect(evaluate(args(emptyContexts))).toEqual("correct");
+    expect(evaluate(args(emptyContexts))).toStrictEqual({
+      configId: propDoesNotEndWithOneOf.id,
+      configKey: propDoesNotEndWithOneOf.key,
+      configType: propDoesNotEndWithOneOf.configType,
+      unwrappedValue: "correct",
+      configRowIndex: 0,
+      selectedValue: { string: "correct" },
+      conditionalValueIndex: 0,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["email", "@prefab.cloud"]])]])))
-    ).toEqual("default");
+    expect(evaluate(args(prefabEmailContexts))).toStrictEqual({
+      configId: propDoesNotEndWithOneOf.id,
+      configKey: propDoesNotEndWithOneOf.key,
+      configType: propDoesNotEndWithOneOf.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["email", "@example.com"]])]])))
-    ).toEqual("default");
+    expect(evaluate(args(exampleEmailContexts))).toStrictEqual({
+      configId: propDoesNotEndWithOneOf.id,
+      configKey: propDoesNotEndWithOneOf.key,
+      configType: propDoesNotEndWithOneOf.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["email", "@hotmail.com"]])]])))
-    ).toEqual("correct");
+    expect(evaluate(args(hotmailEmailContexts))).toStrictEqual({
+      configId: propDoesNotEndWithOneOf.id,
+      configKey: propDoesNotEndWithOneOf.key,
+      configType: propDoesNotEndWithOneOf.configType,
+      unwrappedValue: "correct",
+      configRowIndex: 0,
+      selectedValue: { string: "correct" },
+      conditionalValueIndex: 0,
+      weightedValueIndex: undefined,
+    });
   });
 
-  it("returns a config value for a PROP_IS_ONE_OF and PROP_ENDS_WITH_ONE_OF match", () => {
+  it("returns an evaluation for a PROP_IS_ONE_OF and PROP_ENDS_WITH_ONE_OF match", () => {
     const args = (
       contexts: Map<string, Map<string, string>>
     ): EvaluateArgs => ({
@@ -188,48 +456,77 @@ describe("evaluate", () => {
       resolver: emptyResolver,
     });
 
-    expect(evaluate(args(new Map()))).toEqual("default");
+    expect(evaluate(args(emptyContexts))).toStrictEqual({
+      configId: propIsOneOfAndEndsWith.id,
+      configKey: propIsOneOfAndEndsWith.key,
+      configType: propIsOneOfAndEndsWith.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(args(new Map([["user", new Map([["country", "US"]])]])))
-    ).toEqual("default");
+    expect(evaluate(args(usContexts))).toStrictEqual({
+      configId: propIsOneOfAndEndsWith.id,
+      configKey: propIsOneOfAndEndsWith.key,
+      configType: propIsOneOfAndEndsWith.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(
-        args(new Map([["user", new Map([["email", "test@prefab.cloud"]])]]))
-      )
-    ).toEqual("default");
+    expect(evaluate(args(prefabEmailContexts))).toStrictEqual({
+      configId: propIsOneOfAndEndsWith.id,
+      configKey: propIsOneOfAndEndsWith.key,
+      configType: propIsOneOfAndEndsWith.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(
-        args(
-          new Map([
-            [
-              "user",
-              new Map([
-                ["country", "FR"],
-                ["email", "test@prefab.cloud"],
-              ]),
-            ],
-          ])
-        )
-      )
-    ).toEqual("default");
+    const frPrefabContexts = new Map([
+      [
+        "user",
+        new Map([
+          ["country", "FR"],
+          ["email", "test@prefab.cloud"],
+        ]),
+      ],
+    ]);
+    expect(evaluate(args(frPrefabContexts))).toStrictEqual({
+      configId: propIsOneOfAndEndsWith.id,
+      configKey: propIsOneOfAndEndsWith.key,
+      configType: propIsOneOfAndEndsWith.configType,
+      unwrappedValue: "default",
+      configRowIndex: 0,
+      selectedValue: { string: "default" },
+      conditionalValueIndex: 1,
+      weightedValueIndex: undefined,
+    });
 
-    expect(
-      evaluate(
-        args(
-          new Map([
-            [
-              "user",
-              new Map([
-                ["country", "US"],
-                ["email", "test@prefab.cloud"],
-              ]),
-            ],
-          ])
-        )
-      )
-    ).toEqual("correct");
+    const usPrefabContexts = new Map([
+      [
+        "user",
+        new Map([
+          ["country", "US"],
+          ["email", "test@prefab.cloud"],
+        ]),
+      ],
+    ]);
+    expect(evaluate(args(usPrefabContexts))).toStrictEqual({
+      configId: propIsOneOfAndEndsWith.id,
+      configKey: propIsOneOfAndEndsWith.key,
+      configType: propIsOneOfAndEndsWith.configType,
+      unwrappedValue: "correct",
+      configRowIndex: 0,
+      selectedValue: { string: "correct" },
+      conditionalValueIndex: 0,
+      weightedValueIndex: undefined,
+    });
   });
 });

--- a/src/__tests__/fixtures/basicConfig.ts
+++ b/src/__tests__/fixtures/basicConfig.ts
@@ -4,7 +4,7 @@ import { ConfigType } from "../../proto";
 import { irrelevantLong } from "../testHelpers";
 
 const config: Config = {
-  id: irrelevantLong,
+  id: new Long(999),
   projectId: irrelevantLong,
   key: "basic.value",
   changedBy: undefined,

--- a/src/__tests__/fixtures/basicLogLevel.ts
+++ b/src/__tests__/fixtures/basicLogLevel.ts
@@ -1,9 +1,10 @@
+import Long from "long";
 import type { Config } from "../../proto";
 import { ConfigType, LogLevel } from "../../proto";
 import { irrelevantLong } from "../testHelpers";
 
 const config: Config = {
-  id: irrelevantLong,
+  id: new Long(33),
   projectId: irrelevantLong,
   key: "log-level.some.component.path",
   changedBy: undefined,

--- a/src/__tests__/fixtures/propIsOneOf.ts
+++ b/src/__tests__/fixtures/propIsOneOf.ts
@@ -1,9 +1,10 @@
+import Long from "long";
 import type { Config } from "../../proto";
 import { ConfigType, Criterion_CriterionOperator } from "../../proto";
 import { irrelevantLong, projectEnvIdUnderTest } from "../testHelpers";
 
 const config: Config = {
-  id: irrelevantLong,
+  id: new Long(991),
   projectId: irrelevantLong,
 
   key: "prop.is.one.of",

--- a/src/__tests__/telemetry/evaluationSummaries.test.ts
+++ b/src/__tests__/telemetry/evaluationSummaries.test.ts
@@ -1,0 +1,269 @@
+import Long from "long";
+import { Prefab } from "../../prefab";
+import { evaluationSummaries, stub } from "../../telemetry/evaluationSummaries";
+import { Resolver } from "../../resolver";
+import type { Config } from "../../proto";
+
+import {
+  emptyContexts,
+  projectEnvIdUnderTest,
+  mockApiClient,
+  irrelevant,
+} from "../testHelpers";
+
+import { evaluate, type Evaluation } from "../../evaluate";
+import propIsOneOf from "../fixtures/propIsOneOf";
+import basicConfig from "../fixtures/basicConfig";
+import basicLogLevel from "../fixtures/basicLogLevel";
+import rolloutFlag from "../fixtures/rolloutFlag";
+
+const instanceHash = "instance-hash";
+
+const usContexts = new Map([
+  [
+    "user",
+    new Map([
+      ["trackingId", "abc"],
+      ["country", "US"],
+    ]),
+  ],
+]);
+const ukContexts = new Map([
+  [
+    "user",
+    new Map([
+      ["trackingId", "123"],
+      ["country", "UK"],
+    ]),
+  ],
+]);
+const frContexts = new Map([
+  [
+    "user",
+    new Map([
+      ["trackingId", "xyz"],
+      ["country", "FR"],
+    ]),
+  ],
+]);
+
+const noNamespace = undefined;
+
+// the Resolver is only used to back-reference Segments (which we test in the integration tests) so we can use a stand-in here.
+const emptyResolver = new Resolver(
+  [],
+  projectEnvIdUnderTest,
+  noNamespace,
+  "error"
+);
+
+const evaluationFor = (
+  config: Config,
+  contexts: Map<string, Map<string, string>>
+): Evaluation => {
+  return evaluate({
+    config,
+    projectEnvId: projectEnvIdUnderTest,
+    namespace: noNamespace,
+    contexts,
+    resolver: emptyResolver,
+  });
+};
+
+describe("evaluationSummaries", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it("returns a stub if collectEvaluationSummaries is false", () => {
+    expect(evaluationSummaries(mockApiClient, instanceHash, false)).toBe(stub);
+  });
+
+  it("pushes data", () => {
+    const aggregator = evaluationSummaries(mockApiClient, instanceHash, true);
+
+    aggregator.push(evaluationFor(propIsOneOf, usContexts));
+    aggregator.push(evaluationFor(propIsOneOf, ukContexts));
+    aggregator.push(evaluationFor(propIsOneOf, frContexts));
+    aggregator.push(evaluationFor(propIsOneOf, emptyContexts));
+    aggregator.push(evaluationFor(propIsOneOf, emptyContexts));
+
+    expect(aggregator.data).toEqual(
+      new Map([
+        [
+          '["prop.is.one.of","1"]',
+          new Map([
+            ['["991",0,0,"string","correct",null]', 2],
+            ['["991",1,0,"string","default",null]', 3],
+          ]),
+        ],
+      ])
+    );
+
+    aggregator.push(evaluationFor(propIsOneOf, emptyContexts));
+    aggregator.push(evaluationFor(basicConfig, usContexts));
+
+    // Log level doesn't show up below because we don't report them
+    aggregator.push(evaluationFor(basicLogLevel, usContexts));
+    aggregator.push(evaluationFor(basicLogLevel, emptyContexts));
+
+    expect(aggregator.data).toEqual(
+      new Map([
+        [
+          '["prop.is.one.of","1"]',
+          new Map([
+            ['["991",0,0,"string","correct",null]', 2],
+            ['["991",1,0,"string","default",null]', 4],
+          ]),
+        ],
+        ['["basic.value","1"]', new Map([['["999",0,0,"int",42,null]', 1]])],
+      ])
+    );
+  });
+
+  it("works for weighted values", () => {
+    const aggregator = evaluationSummaries(mockApiClient, instanceHash, true);
+
+    aggregator.push(evaluationFor(rolloutFlag, usContexts));
+    aggregator.push(evaluationFor(rolloutFlag, ukContexts));
+    aggregator.push(evaluationFor(rolloutFlag, frContexts));
+
+    expect(aggregator.data).toStrictEqual(
+      new Map([
+        [
+          '["rollout.flag","2"]',
+          new Map([
+            ['["4294967295",0,0,"weightedValues",false,0]', 2],
+            ['["4294967295",0,0,"weightedValues",true,1]', 1],
+          ]),
+        ],
+      ])
+    );
+  });
+
+  it("should sync to the server", async () => {
+    const aggregator = evaluationSummaries(mockApiClient, instanceHash, true);
+
+    if (!aggregator.enabled) {
+      throw new Error("aggregator is not enabled");
+    }
+
+    aggregator.push(evaluationFor(propIsOneOf, usContexts));
+    aggregator.push(evaluationFor(propIsOneOf, ukContexts));
+    aggregator.push(evaluationFor(propIsOneOf, frContexts));
+    aggregator.push(evaluationFor(propIsOneOf, emptyContexts));
+    aggregator.push(evaluationFor(propIsOneOf, emptyContexts));
+    aggregator.push(evaluationFor(basicConfig, usContexts));
+    aggregator.push(evaluationFor(basicLogLevel, usContexts));
+    aggregator.push(evaluationFor(basicLogLevel, emptyContexts));
+
+    const start = Date.now();
+    jest.advanceTimersByTime(1000);
+
+    const syncResult = await aggregator.sync();
+
+    expect(mockApiClient.fetch).toHaveBeenCalled();
+
+    if (syncResult === undefined) {
+      throw new Error("syncResult is undefined");
+    }
+
+    expect(syncResult.status).toEqual(200);
+
+    expect(syncResult.dataSent).toStrictEqual({
+      instanceHash: "instance-hash",
+      events: [
+        {
+          summaries: {
+            start: Long.fromNumber(start),
+            end: Long.fromNumber(Date.now()),
+            summaries: [
+              {
+                key: "prop.is.one.of",
+                type: "1",
+                counters: [
+                  {
+                    configId: Long.fromNumber(991),
+                    conditionalValueIndex: 0,
+                    configRowIndex: 0,
+                    selectedValue: {
+                      string: "correct",
+                    },
+                    count: Long.fromNumber(2),
+                    weightedValueIndex: null,
+                    reason: 0,
+                  },
+                  {
+                    configId: Long.fromNumber(991),
+                    conditionalValueIndex: 1,
+                    configRowIndex: 0,
+                    selectedValue: {
+                      string: "default",
+                    },
+                    count: Long.fromNumber(3),
+                    weightedValueIndex: null,
+                    reason: 0,
+                  },
+                ],
+              },
+              {
+                key: "basic.value",
+                type: "1",
+                counters: [
+                  {
+                    configId: Long.fromNumber(999),
+                    conditionalValueIndex: 0,
+                    configRowIndex: 0,
+                    selectedValue: {
+                      int: 42,
+                    },
+                    count: Long.fromNumber(1),
+                    weightedValueIndex: null,
+                    reason: 0,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(aggregator.data).toStrictEqual(new Map());
+  });
+
+  describe("integration tests", () => {
+    it("records evaluation summaries by default", () => {
+      const prefab = new Prefab({
+        apiKey: irrelevant,
+      });
+      prefab.setConfig([basicConfig], projectEnvIdUnderTest);
+
+      prefab.get("basic.value", usContexts);
+
+      expect(prefab.telemetry.evaluationSummaries.data).toStrictEqual(
+        new Map([
+          ['["basic.value","1"]', new Map([['["999",0,0,"int",42,null]', 1]])],
+        ])
+      );
+    });
+
+    it("does not record evaluation summaries when collectEvaluationSummaries is false", () => {
+      const prefab = new Prefab({
+        apiKey: irrelevant,
+        collectEvaluationSummaries: false,
+      });
+      prefab.setConfig([basicConfig], projectEnvIdUnderTest);
+
+      prefab.get("basic.value", usContexts);
+
+      expect(prefab.telemetry.evaluationSummaries.data).toStrictEqual(
+        new Map()
+      );
+    });
+  });
+});

--- a/src/__tests__/telemetry/exampleContexts.test.ts
+++ b/src/__tests__/telemetry/exampleContexts.test.ts
@@ -1,5 +1,4 @@
 import Long from "long";
-
 import { Prefab } from "../../prefab";
 import { exampleContexts, stub } from "../../telemetry/exampleContexts";
 import type { Contexts } from "../../types";

--- a/src/__tests__/unwrap.test.ts
+++ b/src/__tests__/unwrap.test.ts
@@ -12,25 +12,33 @@ describe("unwrapValue", () => {
 
   it("should return the string value", () => {
     const value: ConfigValue = { string: "test" };
-    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toBe("test");
+    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toStrictEqual([
+      "test",
+      undefined,
+    ]);
   });
 
   it("should return the int value as a number", () => {
     const value: ConfigValue = { int: Long.fromInt(42) };
-    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toBe(42);
+    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toStrictEqual([
+      42,
+      undefined,
+    ]);
   });
 
   it("should return the bool value", () => {
     const value: ConfigValue = { bool: true };
-    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toBe(true);
+    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toStrictEqual([
+      true,
+      undefined,
+    ]);
   });
 
   it("should return the stringList values as an array", () => {
     const value: ConfigValue = { stringList: { values: ["a", "b", "c"] } };
-    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toEqual([
-      "a",
-      "b",
-      "c",
+    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toStrictEqual([
+      ["a", "b", "c"],
+      undefined,
     ]);
   });
 
@@ -46,13 +54,13 @@ describe("unwrapValue", () => {
     };
 
     jest.spyOn(global.Math, "random").mockReturnValue(0.5);
-    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toEqual("b");
+    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toEqual(["b", 1]);
 
     jest.spyOn(global.Math, "random").mockReturnValue(0.1);
-    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toEqual("a");
+    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toEqual(["a", 0]);
 
     jest.spyOn(global.Math, "random").mockReturnValue(0.8);
-    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toEqual("c");
+    expect(unwrapValue(key, value, emptyHashByPropertyValue)).toEqual(["c", 2]);
   });
 
   it("should return a consistent weighted value with context", () => {
@@ -66,9 +74,9 @@ describe("unwrapValue", () => {
       },
     };
 
-    expect(unwrapValue(key, value, "100")).toEqual("a");
-    expect(unwrapValue(key, value, "110")).toEqual("b");
-    expect(unwrapValue(key, value, "101")).toEqual("c");
+    expect(unwrapValue(key, value, "100")).toEqual(["a", 0]);
+    expect(unwrapValue(key, value, "110")).toEqual(["b", 1]);
+    expect(unwrapValue(key, value, "101")).toEqual(["c", 2]);
   });
 
   it("should throw an error for unexpected values", () => {
@@ -81,11 +89,17 @@ describe("unwrapValue", () => {
 
 describe("unwrap", () => {
   it("should return undefined for undefined input", () => {
-    expect(unwrap(key, undefined, emptyHashByPropertyValue)).toBeUndefined();
+    expect(unwrap(key, undefined, emptyHashByPropertyValue)).toStrictEqual([
+      undefined,
+      undefined,
+    ]);
   });
 
   it("should return the value from unwrapValue for non-undefined input", () => {
     const value: ConfigValue = { string: "test" };
-    expect(unwrap(key, value, emptyHashByPropertyValue)).toBe("test");
+    expect(unwrap(key, value, emptyHashByPropertyValue)).toStrictEqual([
+      "test",
+      undefined,
+    ]);
   });
 });

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -17,6 +17,7 @@ import type { ContextUploadMode } from "./telemetry/types";
 import { knownLoggers } from "./telemetry/knownLoggers";
 import { contextShapes } from "./telemetry/contextShapes";
 import { exampleContexts } from "./telemetry/exampleContexts";
+import { evaluationSummaries } from "./telemetry/evaluationSummaries";
 
 const DEFAULT_POLL_INTERVAL = 60 * 1000;
 const PREFAB_DEFAULT_LOG_LEVEL = LogLevel.WARN;
@@ -38,6 +39,7 @@ export interface Telemetry {
   knownLoggers: ReturnType<typeof knownLoggers>;
   contextShapes: ReturnType<typeof contextShapes>;
   exampleContexts: ReturnType<typeof exampleContexts>;
+  evaluationSummaries: ReturnType<typeof evaluationSummaries>;
 }
 
 interface ConstructorProps {
@@ -53,6 +55,7 @@ interface ConstructorProps {
   defaultLogLevel?: ValidLogLevel | ValidLogLevelName;
   collectLoggerCounts?: boolean;
   contextUploadMode?: ContextUploadMode;
+  collectEvaluationSummaries?: boolean;
 }
 
 class Prefab implements PrefabInterface {
@@ -67,10 +70,8 @@ class Prefab implements PrefabInterface {
   private resolver?: Resolver;
   private readonly apiClient: ApiClient;
   private readonly defaultLogLevel: ValidLogLevel;
+  private readonly instanceHash: string;
   readonly telemetry: Telemetry;
-
-  readonly instanceHash: string;
-  readonly collectLoggerCounts: boolean;
 
   constructor({
     apiKey,
@@ -85,6 +86,7 @@ class Prefab implements PrefabInterface {
     defaultLogLevel = PREFAB_DEFAULT_LOG_LEVEL,
     collectLoggerCounts = true,
     contextUploadMode = "periodicExample",
+    collectEvaluationSummaries = true,
   }: ConstructorProps) {
     this.apiKey = apiKey;
     this.apiUrl = apiUrl ?? "https://api.prefab.cloud";
@@ -95,7 +97,6 @@ class Prefab implements PrefabInterface {
     this.onNoDefault = onNoDefault ?? "error";
     this.pollInterval = pollInterval ?? DEFAULT_POLL_INTERVAL;
     this.instanceHash = crypto.randomUUID();
-    this.collectLoggerCounts = collectLoggerCounts;
 
     const parsedDefaultLogLevel = parseLevel(defaultLogLevel);
 
@@ -121,6 +122,11 @@ class Prefab implements PrefabInterface {
         this.apiClient,
         this.instanceHash,
         contextUploadMode
+      ),
+      evaluationSummaries: evaluationSummaries(
+        this.apiClient,
+        this.instanceHash,
+        collectEvaluationSummaries
       ),
     };
   }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -92,13 +92,19 @@ class Resolver implements PrefabInterface {
       this.telemetry.exampleContexts.push(mergedContexts);
     }
 
-    return evaluate({
+    const evaluation = evaluate({
       config,
       projectEnvId: this.projectEnvId,
       namespace: this.namespace,
       contexts: mergedContexts,
       resolver: this,
     });
+
+    if (this.telemetry !== undefined) {
+      this.telemetry.evaluationSummaries.push(evaluation);
+    }
+
+    return evaluation.unwrappedValue;
   }
 
   isFeatureEnabled(key: string, contexts?: Contexts): boolean {

--- a/src/telemetry/evaluationSummaries.ts
+++ b/src/telemetry/evaluationSummaries.ts
@@ -1,0 +1,169 @@
+import Long from "long";
+import type { SyncResult, Telemetry } from "./types";
+import type { ApiClient } from "../apiClient";
+import type { Evaluation } from "../evaluate";
+import type {
+  ConfigEvaluationCounter,
+  ConfigEvaluationSummary,
+  TelemetryEvent,
+  TelemetryEvents,
+} from "../proto";
+import { ConfigType } from "../proto";
+import { encode } from "../parseProto";
+import { now } from "./reporter";
+
+const ENDPOINT = "/api/v1/telemetry";
+
+type CounterKey = string;
+type Counter = Map<string, number>;
+
+type EvaluationSummariesTelemetry = Telemetry & {
+  push: (evaluation: Evaluation) => void;
+  data: Map<CounterKey, Counter>;
+};
+
+export const stub: EvaluationSummariesTelemetry = {
+  enabled: false,
+  sync: async () => undefined,
+  timeout: undefined,
+  data: new Map(),
+  push: () => {},
+};
+
+export const evaluationSummaries = (
+  apiClient: ApiClient,
+  instanceHash: string,
+  collectEvaluationSummaries: boolean
+): EvaluationSummariesTelemetry => {
+  if (!collectEvaluationSummaries) {
+    return stub;
+  }
+
+  let startAt: Long | undefined;
+  const data: EvaluationSummariesTelemetry["data"] = new Map();
+
+  const incrementCounter = (key: string, counter: string): void => {
+    const countersForKey = data.get(key);
+
+    let newCount = 0;
+
+    if (countersForKey !== undefined) {
+      newCount = countersForKey.get(counter) ?? 0;
+    }
+
+    data.set(
+      key,
+      new Map([...(countersForKey ?? []), [counter, newCount + 1]])
+    );
+  };
+
+  return {
+    enabled: true,
+
+    data,
+
+    timeout: undefined,
+
+    push(evaluation: Evaluation): void {
+      startAt = startAt ?? now();
+
+      if (
+        evaluation.selectedValue === undefined ||
+        evaluation.configType === ConfigType.LOG_LEVEL
+      ) {
+        return;
+      }
+
+      const key = JSON.stringify([
+        evaluation.configKey,
+        evaluation.configType.toString(),
+      ]);
+
+      const counter = JSON.stringify([
+        evaluation.configId.toString(),
+        evaluation.conditionalValueIndex,
+        evaluation.configRowIndex,
+        Object.keys(evaluation.selectedValue)[0],
+        evaluation.unwrappedValue,
+        evaluation.weightedValueIndex,
+      ]);
+
+      incrementCounter(key, counter);
+    },
+
+    sync: async (): Promise<SyncResult | undefined> => {
+      if (data.size === 0) {
+        return undefined;
+      }
+
+      const summaries: ConfigEvaluationSummary[] = [];
+
+      data.forEach((rawCounters, keyJSON) => {
+        const [key, type] = JSON.parse(keyJSON);
+
+        const counters: ConfigEvaluationCounter[] = [];
+
+        rawCounters.forEach((count, counterJSON) => {
+          const [
+            configId,
+            conditionalValueIndex,
+            configRowIndex,
+            valueType,
+            unwrappedValue,
+            weightedValueIndex,
+          ] = JSON.parse(counterJSON);
+
+          const counter: ConfigEvaluationCounter = {
+            configId: new Long(configId),
+            conditionalValueIndex,
+            configRowIndex,
+            selectedValue: { [valueType]: unwrappedValue },
+            count: Long.fromNumber(count),
+            weightedValueIndex,
+            reason: 0,
+          };
+
+          counters.push(counter);
+        });
+
+        const summary: ConfigEvaluationSummary = {
+          key,
+          type,
+          counters,
+        };
+
+        summaries.push(summary);
+
+        data.delete(keyJSON);
+      });
+
+      const event: TelemetryEvent = {
+        summaries: {
+          start: startAt ?? new Long(Date.now()),
+          end: now(),
+          summaries,
+        },
+      };
+
+      const apiData: TelemetryEvents = {
+        instanceHash,
+        events: [event],
+      };
+
+      const body = encode("TelemetryEvents", apiData);
+
+      const result = await apiClient.fetch({
+        path: ENDPOINT,
+        options: {
+          method: "POST",
+          body,
+        },
+      });
+
+      return {
+        status: result.status,
+        dataSent: apiData,
+      };
+    },
+  };
+};


### PR DESCRIPTION
Enabled by default, this sends data to Prefab about how frequently a
config/flag is serving a particular value.

This powers the evaluation metrics/charts in the Prefab UI.

You can disable it by setting `collectEvaluationSummaries: false` in the
options.
