### PR TITLE
onUpdate and default context

### DIFF
--- a/src/__tests__/evaluate.test.ts
+++ b/src/__tests__/evaluate.test.ts
@@ -239,7 +239,7 @@ describe("evaluate", () => {
       unwrappedValue: "default",
       configRowIndex: 0,
       selectedValue: { string: "default" },
-      conditionalValueIndex: 1,
+      conditionalValueIndex: 2,
       weightedValueIndex: undefined,
     });
 
@@ -250,7 +250,7 @@ describe("evaluate", () => {
       unwrappedValue: "correct",
       configRowIndex: 0,
       selectedValue: { string: "correct" },
-      conditionalValueIndex: 0,
+      conditionalValueIndex: 1,
       weightedValueIndex: undefined,
     });
 
@@ -261,7 +261,7 @@ describe("evaluate", () => {
       unwrappedValue: "correct",
       configRowIndex: 0,
       selectedValue: { string: "correct" },
-      conditionalValueIndex: 0,
+      conditionalValueIndex: 1,
       weightedValueIndex: undefined,
     });
 
@@ -272,7 +272,7 @@ describe("evaluate", () => {
       unwrappedValue: "default",
       configRowIndex: 0,
       selectedValue: { string: "default" },
-      conditionalValueIndex: 1,
+      conditionalValueIndex: 2,
       weightedValueIndex: undefined,
     });
   });

--- a/src/__tests__/fixtures/propIsOneOf.ts
+++ b/src/__tests__/fixtures/propIsOneOf.ts
@@ -29,6 +29,22 @@ const config: Config = {
         {
           criteria: [
             {
+              propertyName: "prefab.user-id",
+              operator: Criterion_CriterionOperator.PROP_IS_ONE_OF,
+              valueToMatch: {
+                stringList: {
+                  values: ["4", "5"],
+                },
+              },
+            },
+          ],
+          value: {
+            string: "context-override",
+          },
+        },
+        {
+          criteria: [
+            {
               propertyName: "user.country",
               operator: Criterion_CriterionOperator.PROP_IS_ONE_OF,
               valueToMatch: {

--- a/src/__tests__/telemetry/contextShapes.test.ts
+++ b/src/__tests__/telemetry/contextShapes.test.ts
@@ -144,7 +144,7 @@ describe("contextShapes", () => {
         apiKey: irrelevant,
         contextUploadMode: "shapeOnly",
       });
-      prefab.setConfig([basicConfig], projectEnvIdUnderTest);
+      prefab.setConfig([basicConfig], projectEnvIdUnderTest, new Map());
 
       prefab.get("basic.value", contexts);
 
@@ -164,7 +164,11 @@ describe("contextShapes", () => {
       const prefabWithoutShapes = new Prefab({
         apiKey: irrelevant,
       });
-      prefabWithoutShapes.setConfig([basicConfig], projectEnvIdUnderTest);
+      prefabWithoutShapes.setConfig(
+        [basicConfig],
+        projectEnvIdUnderTest,
+        new Map()
+      );
 
       prefabWithoutShapes.get("basic.value", contexts);
 

--- a/src/__tests__/telemetry/evaluationSummaries.test.ts
+++ b/src/__tests__/telemetry/evaluationSummaries.test.ts
@@ -97,8 +97,8 @@ describe("evaluationSummaries", () => {
         [
           '["prop.is.one.of","1"]',
           new Map([
-            ['["991",0,0,"string","correct",null]', 2],
-            ['["991",1,0,"string","default",null]', 3],
+            ['["991",1,0,"string","correct",null]', 2],
+            ['["991",2,0,"string","default",null]', 3],
           ]),
         ],
       ])
@@ -116,8 +116,8 @@ describe("evaluationSummaries", () => {
         [
           '["prop.is.one.of","1"]',
           new Map([
-            ['["991",0,0,"string","correct",null]', 2],
-            ['["991",1,0,"string","default",null]', 4],
+            ['["991",1,0,"string","correct",null]', 2],
+            ['["991",2,0,"string","default",null]', 4],
           ]),
         ],
         ['["basic.value","1"]', new Map([['["999",0,0,"int",42,null]', 1]])],
@@ -188,7 +188,7 @@ describe("evaluationSummaries", () => {
                 counters: [
                   {
                     configId: Long.fromNumber(991),
-                    conditionalValueIndex: 0,
+                    conditionalValueIndex: 1,
                     configRowIndex: 0,
                     selectedValue: {
                       string: "correct",
@@ -198,7 +198,7 @@ describe("evaluationSummaries", () => {
                   },
                   {
                     configId: Long.fromNumber(991),
-                    conditionalValueIndex: 1,
+                    conditionalValueIndex: 2,
                     configRowIndex: 0,
                     selectedValue: {
                       string: "default",
@@ -253,7 +253,7 @@ describe("evaluationSummaries", () => {
       const prefab = new Prefab({
         apiKey: irrelevant,
       });
-      prefab.setConfig([basicConfig], projectEnvIdUnderTest);
+      prefab.setConfig([basicConfig], projectEnvIdUnderTest, new Map());
 
       prefab.get("basic.value", usContexts);
 
@@ -269,7 +269,7 @@ describe("evaluationSummaries", () => {
         apiKey: irrelevant,
         collectEvaluationSummaries: false,
       });
-      prefab.setConfig([basicConfig], projectEnvIdUnderTest);
+      prefab.setConfig([basicConfig], projectEnvIdUnderTest, new Map());
 
       prefab.get("basic.value", usContexts);
 

--- a/src/__tests__/telemetry/exampleContexts.test.ts
+++ b/src/__tests__/telemetry/exampleContexts.test.ts
@@ -211,7 +211,7 @@ describe("exampleContexts", () => {
       const prefab = new Prefab({
         apiKey: irrelevant,
       });
-      prefab.setConfig([basicConfig], projectEnvIdUnderTest);
+      prefab.setConfig([basicConfig], projectEnvIdUnderTest, new Map());
 
       prefab.get("basic.value", contexts);
 
@@ -225,7 +225,7 @@ describe("exampleContexts", () => {
         apiKey: irrelevant,
         contextUploadMode: "none",
       });
-      prefab.setConfig([basicConfig], projectEnvIdUnderTest);
+      prefab.setConfig([basicConfig], projectEnvIdUnderTest, new Map());
 
       prefab.get("basic.value", contexts);
 

--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -1,9 +1,10 @@
 import type Long from "long";
+import type { Config, Configs } from "./proto";
 import { maxLong } from "./maxLong";
 import type { ApiClient } from "./apiClient";
 
-import type { Config } from "./proto";
-import type { ProjectEnvId } from "./types";
+import { unwrap } from "./unwrap";
+import type { Contexts, ProjectEnvId } from "./types";
 import { parseConfigs } from "./parseProto";
 
 export async function loadConfig({
@@ -20,6 +21,7 @@ export async function loadConfig({
   configs: Config[];
   projectEnvId: ProjectEnvId;
   startAtId: Long;
+  defaultContext: Contexts;
 }> {
   try {
     return await loadConfigFromUrl({ url: cdnUrl, startAtId, apiClient });
@@ -28,6 +30,27 @@ export async function loadConfig({
     return await loadConfigFromUrl({ url: apiUrl, startAtId, apiClient });
   }
 }
+
+const extractDefaultContext = (
+  rawDefaultContext: Configs["defaultContext"]
+): Contexts => {
+  const defaultContext: Contexts = new Map();
+
+  for (const context of rawDefaultContext?.contexts ?? []) {
+    if (context.type !== undefined) {
+      const values = new Map<string, unknown>();
+
+      for (const key of Object.keys(context.values ?? {})) {
+        const [value] = unwrap(key, context.values[key], undefined);
+        values.set(key, value);
+      }
+
+      defaultContext.set(context.type, values);
+    }
+  }
+
+  return defaultContext;
+};
 
 const loadConfigFromUrl = async ({
   url,
@@ -57,10 +80,13 @@ const loadConfigFromUrl = async ({
 
     const configs = parsed.configs ?? [];
 
+    const defaultContext = extractDefaultContext(parsed.defaultContext);
+
     return {
       configs,
       projectEnvId: parsed.configServicePointer.projectEnvId,
       startAtId: maxLong(configs.map((c) => c.id)),
+      defaultContext,
     };
   }
 

--- a/src/proto.json
+++ b/src/proto.json
@@ -178,15 +178,33 @@
               }
             },
             "userId": {
-              "type": "int64",
-              "id": 2,
+              "type": "string",
+              "id": 3,
               "options": {
                 "proto3_optional": true
               }
             }
-          }
+          },
+          "reserved": [
+            [
+              2,
+              2
+            ]
+          ]
         },
         "Configs": {
+          "oneofs": {
+            "_apikeyMetadata": {
+              "oneof": [
+                "apikeyMetadata"
+              ]
+            },
+            "_defaultContext": {
+              "oneof": [
+                "defaultContext"
+              ]
+            }
+          },
           "fields": {
             "configs": {
               "rule": "repeated",
@@ -199,7 +217,17 @@
             },
             "apikeyMetadata": {
               "type": "ApiKeyMetadata",
-              "id": 3
+              "id": 3,
+              "options": {
+                "proto3_optional": true
+              }
+            },
+            "defaultContext": {
+              "type": "ContextSet",
+              "id": 4,
+              "options": {
+                "proto3_optional": true
+              }
             }
           }
         },
@@ -701,6 +729,18 @@
           }
         },
         "ConfigEvaluations": {
+          "oneofs": {
+            "_apikeyMetadata": {
+              "oneof": [
+                "apikeyMetadata"
+              ]
+            },
+            "_defaultContext": {
+              "oneof": [
+                "defaultContext"
+              ]
+            }
+          },
           "fields": {
             "values": {
               "keyType": "string",
@@ -709,7 +749,17 @@
             },
             "apikeyMetadata": {
               "type": "ApiKeyMetadata",
-              "id": 2
+              "id": 2,
+              "options": {
+                "proto3_optional": true
+              }
+            },
+            "defaultContext": {
+              "type": "ContextSet",
+              "id": 3,
+              "options": {
+                "proto3_optional": true
+              }
             }
           }
         },

--- a/src/proto.ts
+++ b/src/proto.ts
@@ -84,14 +84,18 @@ export interface WeightedValues {
 
 export interface ApiKeyMetadata {
   /** numeric currently, but making it string will be more flexible over time */
-  keyId?: string | undefined;
-  userId?: Long | undefined;
+  keyId?:
+    | string
+    | undefined;
+  /** ditto */
+  userId?: string | undefined;
 }
 
 export interface Configs {
   configs: Config[];
   configServicePointer: ConfigServicePointer | undefined;
-  apikeyMetadata: ApiKeyMetadata | undefined;
+  apikeyMetadata?: ApiKeyMetadata | undefined;
+  defaultContext?: ContextSet | undefined;
 }
 
 export interface Config {
@@ -255,7 +259,8 @@ export interface ClientConfigValue {
 
 export interface ConfigEvaluations {
   values: { [key: string]: ClientConfigValue };
-  apikeyMetadata: ApiKeyMetadata | undefined;
+  apikeyMetadata?: ApiKeyMetadata | undefined;
+  defaultContext?: ContextSet | undefined;
 }
 
 export interface ConfigEvaluations_ValuesEntry {


### PR DESCRIPTION
- onUpdate can be used to take action when config changes.
- default context allows for per-api-key/user overrides
