### PR TITLE
feat(Context): Accept objects for context

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ prefab.inContext(context, (pf) => {
 })
 ```
 
+Note that you can also provide Context as an object instead of a Map, e.g.:
+
+```javascript
+{
+  user: {
+    key: "some-unique-identifier",
+    country: "US"
+  },
+  subscription: {
+    key: "pro-sub",
+    plan: "pro"
+  }
+}
+```
+
 #### Option Definitions
 
 Besides `apiKey`, you can initialize `new Prefab(...)` with the following options

--- a/src/__tests__/prefab.test.ts
+++ b/src/__tests__/prefab.test.ts
@@ -236,6 +236,17 @@ describe("prefab", () => {
       ).toEqual("context-override");
     });
 
+    it("can use a Context object instead of a Context map", () => {
+      const prefab = new Prefab({ apiKey: irrelevant });
+      prefab.setConfig(configs, projectEnvIdUnderTest, new Map());
+
+      expect(
+        prefab.get("prop.is.one.of", {
+          user: { country: "US", "user-id": "5" },
+        })
+      ).toEqual("correct");
+    });
+
     it("returns a decrypted secret", () => {
       const decryptionKey = generateNewHexKey();
       const clearText = "very secret stuff";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import type { Contexts } from "./types";
+import type { ContextObj, Contexts } from "./types";
 import { type Resolver } from "./resolver";
 
 export const PREFIX = "log-level.";
@@ -53,7 +53,7 @@ export const shouldLog = ({
   desiredLevel: ValidLogLevel;
   defaultLevel: ValidLogLevel;
   resolver: Resolver;
-  contexts?: Contexts;
+  contexts?: Contexts | ContextObj;
 }): boolean => {
   let loggerNameWithPrefix = PREFIX + loggerName;
 

--- a/src/mergeContexts.ts
+++ b/src/mergeContexts.ts
@@ -1,15 +1,32 @@
-import type { Contexts } from "./types";
+import type { Contexts, Context, ContextObj } from "./types";
+
+export const contextObjToMap = (obj: ContextObj): Contexts => {
+  const outerMap: Contexts = new Map<string, Context>();
+
+  for (const [outerKey, innerObj] of Object.entries(obj)) {
+    const innerMap: Context = new Map<string, unknown>();
+    for (const [innerKey, innerValue] of Object.entries(innerObj)) {
+      innerMap.set(innerKey, innerValue);
+    }
+
+    outerMap.set(outerKey, innerMap);
+  }
+
+  return outerMap;
+};
 
 export const mergeContexts = (
   parent: Contexts | undefined,
-  local: Contexts
+  local: Contexts | ContextObj
 ): Contexts => {
+  const localContext = local instanceof Map ? local : contextObjToMap(local);
+
   if (parent === undefined) {
-    return local;
+    return localContext;
   }
 
   const merged = new Map(parent);
-  for (const [key, value] of local) {
+  for (const [key, value] of localContext) {
     merged.set(key, value);
   }
 

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -3,7 +3,13 @@ import type Long from "long";
 import { apiClient, type ApiClient } from "./apiClient";
 import { loadConfig } from "./loadConfig";
 import { Resolver } from "./resolver";
-import type { Contexts, Fetch, OnNoDefault, ProjectEnvId } from "./types";
+import type {
+  ContextObj,
+  Contexts,
+  Fetch,
+  OnNoDefault,
+  ProjectEnvId,
+} from "./types";
 import {
   ConfigType,
   Config_ValueType as ConfigValueType,
@@ -42,8 +48,12 @@ function requireResolver(
 }
 
 export interface PrefabInterface {
-  get: (key: string, contexts?: Contexts, defaultValue?: GetValue) => GetValue;
-  isFeatureEnabled: (key: string, contexts?: Contexts) => boolean;
+  get: (
+    key: string,
+    contexts?: Contexts | ContextObj,
+    defaultValue?: GetValue
+  ) => GetValue;
+  isFeatureEnabled: (key: string, contexts?: Contexts | ContextObj) => boolean;
 }
 
 export interface Telemetry {
@@ -229,13 +239,20 @@ class Prefab implements PrefabInterface {
     poll();
   }
 
-  inContext(contexts: Contexts, func: (prefab: Resolver) => void): void {
+  inContext(
+    contexts: Contexts | ContextObj,
+    func: (prefab: Resolver) => void
+  ): void {
     requireResolver(this.resolver);
 
     func(this.resolver.cloneWithContext(contexts));
   }
 
-  get(key: string, contexts?: Contexts, defaultValue?: GetValue): GetValue {
+  get(
+    key: string,
+    contexts?: Contexts | ContextObj,
+    defaultValue?: GetValue
+  ): GetValue {
     requireResolver(this.resolver);
 
     return this.resolver.get(key, contexts, defaultValue);
@@ -250,7 +267,7 @@ class Prefab implements PrefabInterface {
     loggerName: string;
     desiredLevel: ValidLogLevel | ValidLogLevelName;
     defaultLevel?: ValidLogLevel | ValidLogLevelName;
-    contexts?: Contexts;
+    contexts?: Contexts | ContextObj;
   }): boolean {
     const numericDesiredLevel = parseLevel(desiredLevel);
 
@@ -283,7 +300,7 @@ class Prefab implements PrefabInterface {
     );
   }
 
-  isFeatureEnabled(key: string, contexts?: Contexts): boolean {
+  isFeatureEnabled(key: string, contexts?: Contexts | ContextObj): boolean {
     requireResolver(this.resolver);
 
     return this.resolver.isFeatureEnabled(key, contexts);
@@ -301,7 +318,7 @@ class Prefab implements PrefabInterface {
     return this.resolver.keys();
   }
 
-  defaultContext(): Contexts | undefined {
+  defaultContext(): Contexts | ContextObj | undefined {
     requireResolver(this.resolver);
 
     return this.resolver.defaultContext;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ export type Context = Map<ContextKey, ContextValue>;
 
 export type Contexts = Map<ContextName, Context>;
 
+export type ContextObj = Record<string, Record<string, unknown>>;
+
 export type ProjectEnvId = Long;
 
 export type HashByPropertyValue = string | undefined;


### PR DESCRIPTION
e.g.

```javascript
{ user: { country: "US", "user-id": "5" } }
```

is valid context now. This can save a developer from having to Map-ify
things on their end.
