### PR TITLE
Feat: Allow prefab.set (experimental)

### DIFF
--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -1,13 +1,12 @@
 import type Long from "long";
 import type {
   ConditionalValue,
-  Config,
   ConfigRow,
   ConfigValue,
   Criterion,
 } from "./proto";
 import { Criterion_CriterionOperator } from "./proto";
-import type { Resolver } from "./resolver";
+import type { Resolver, MinimumConfig } from "./resolver";
 import type { Contexts, HashByPropertyValue, ProjectEnvId } from "./types";
 import type { GetValue } from "./unwrap";
 import { unwrap } from "./unwrap";
@@ -144,7 +143,7 @@ const matchingConfigValue = (
 };
 
 export interface EvaluateArgs {
-  config: Config;
+  config: MinimumConfig;
   projectEnvId: ProjectEnvId;
   namespace: string | undefined;
   contexts: Contexts;
@@ -152,7 +151,7 @@ export interface EvaluateArgs {
 }
 
 export interface Evaluation {
-  configId: Long;
+  configId: Long | undefined;
   configKey: string;
   configType: number;
   unwrappedValue: GetValue;

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import type Long from "long";
 import { apiClient, type ApiClient } from "./apiClient";
 import { loadConfig } from "./loadConfig";
-import { Resolver } from "./resolver";
+import { Resolver, type MinimumConfig } from "./resolver";
 import type {
   ContextObj,
   Contexts,
@@ -163,7 +163,9 @@ class Prefab implements PrefabInterface {
     };
   }
 
-  async init(): Promise<void> {
+  async init(
+    runtimeConfig: Array<[key: string, value: ConfigValue]> = []
+  ): Promise<void> {
     this.initCount += 1;
 
     if (this.initCount > 1 && (this.enableSSE || this.enablePolling)) {
@@ -179,6 +181,10 @@ class Prefab implements PrefabInterface {
       });
 
     this.setConfig(configs, projectEnvId, defaultContext);
+
+    runtimeConfig.forEach(([key, value]) => {
+      this.set(key, value);
+    });
 
     if (this.enableSSE) {
       this.startSSE(startAtId);
@@ -315,7 +321,7 @@ class Prefab implements PrefabInterface {
     return this.resolver.isFeatureEnabled(key, contexts);
   }
 
-  raw(key: string): Config | undefined {
+  raw(key: string): MinimumConfig | undefined {
     requireResolver(this.resolver);
 
     return this.resolver.raw(key);
@@ -331,6 +337,12 @@ class Prefab implements PrefabInterface {
     requireResolver(this.resolver);
 
     return this.resolver.defaultContext;
+  }
+
+  set(key: string, value: ConfigValue): void {
+    requireResolver(this.resolver);
+
+    this.resolver.set(key, value);
   }
 }
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,4 +1,5 @@
-import type { Config } from "./proto";
+import type { Config, ConfigValue } from "./proto";
+import { ConfigType } from "./proto";
 import type {
   ContextObj,
   Context,
@@ -11,11 +12,20 @@ import type { PrefabInterface, Telemetry } from "./prefab";
 import { mergeContexts, contextObjToMap } from "./mergeContexts";
 
 import type { GetValue } from "./unwrap";
+import { configValueType } from "./wrap";
 import { evaluate } from "./evaluate";
 
 const emptyContexts: Contexts = new Map<string, Context>();
 
 export const NOT_PROVIDED = Symbol("NOT_PROVIDED");
+
+type OptionalKeys = "id" | "projectId" | "changedBy" | "allowableValues";
+
+export type MinimumConfig = {
+  [K in keyof Config]: K extends OptionalKeys
+    ? Config[K] | undefined
+    : Config[K];
+};
 
 const mergeDefaultContexts = (
   contexts: Contexts | ContextObj,
@@ -40,7 +50,7 @@ const mergeDefaultContexts = (
 };
 
 class Resolver implements PrefabInterface {
-  private readonly config: Map<string, Config>;
+  private readonly config: Map<string, MinimumConfig>;
   private readonly projectEnvId: ProjectEnvId;
   private readonly namespace: string | undefined;
   private readonly onNoDefault: OnNoDefault;
@@ -50,7 +60,7 @@ class Resolver implements PrefabInterface {
   public readonly defaultContext?: Contexts;
 
   constructor(
-    configs: Config[] | Map<string, Config>,
+    configs: Config[] | Map<string, MinimumConfig>,
     projectEnvId: ProjectEnvId,
     namespace: string | undefined,
     onNoDefault: OnNoDefault,
@@ -102,8 +112,29 @@ class Resolver implements PrefabInterface {
     this.onUpdate(configs);
   }
 
-  raw(key: string): Config | undefined {
+  raw(key: string): MinimumConfig | undefined {
     return this.config.get(key);
+  }
+
+  set(key: string, value: ConfigValue): void {
+    const valueType = configValueType(value);
+
+    if (!valueType) {
+      throw new Error(`Unknown value type for ${JSON.stringify(value)}`);
+    }
+
+    const config: MinimumConfig = {
+      id: undefined,
+      projectId: undefined,
+      changedBy: undefined,
+      allowableValues: undefined,
+      key,
+      rows: [{ properties: {}, values: [{ value, criteria: [] }] }],
+      configType: ConfigType.CONFIG,
+      valueType,
+    };
+
+    this.config.set(key, config);
   }
 
   get(
@@ -135,7 +166,7 @@ class Resolver implements PrefabInterface {
       contexts ?? emptyContexts
     );
 
-    if (this.telemetry !== undefined) {
+    if (this.telemetry !== undefined && config.id !== undefined) {
       this.telemetry.contextShapes.push(mergedContexts);
       this.telemetry.exampleContexts.push(mergedContexts);
     }
@@ -148,7 +179,7 @@ class Resolver implements PrefabInterface {
       resolver: this,
     });
 
-    if (this.telemetry !== undefined) {
+    if (this.telemetry !== undefined && config.id !== undefined) {
       this.telemetry.evaluationSummaries.push(evaluation);
     }
 

--- a/src/telemetry/evaluationSummaries.ts
+++ b/src/telemetry/evaluationSummaries.ts
@@ -67,6 +67,10 @@ export const evaluationSummaries = (
     timeout: undefined,
 
     push(evaluation: Evaluation): void {
+      if (evaluation.configId === undefined) {
+        return;
+      }
+
       if (data.size >= maxDataSize) {
         return;
       }

--- a/src/unwrap.ts
+++ b/src/unwrap.ts
@@ -1,9 +1,9 @@
 import { createHash } from "crypto";
-import type { Config, ConfigValue, Provided, WeightedValue } from "./proto";
+import type { ConfigValue, Provided, WeightedValue } from "./proto";
 import { Config_ValueType, ProvidedSource } from "./proto";
 import type { HashByPropertyValue } from "./types";
 import { isNonNullable } from "./types";
-import type { Resolver } from "./resolver";
+import type { MinimumConfig, Resolver } from "./resolver";
 import { decrypt } from "./encryption";
 
 import murmurhash from "murmurhash";
@@ -32,7 +32,7 @@ export const NULL_UNWRAPPED_VALUE: UnwrappedValue = {
 };
 
 const kindOf = (
-  config: Config | undefined,
+  config: MinimumConfig | undefined,
   value: ConfigValue
 ): keyof ConfigValue | undefined => {
   const kind: keyof ConfigValue | undefined =
@@ -98,7 +98,7 @@ const unwrapWeightedValues = (
 };
 
 const providedValue = (
-  config: Config,
+  config: MinimumConfig,
   provided: Provided | undefined
 ): GetValue => {
   if (provided == null) {
@@ -149,7 +149,7 @@ const configValueTypeToString = (
   }
 };
 
-const coerceIntoType = (config: Config, value: string): GetValue => {
+const coerceIntoType = (config: MinimumConfig, value: string): GetValue => {
   switch (config.valueType) {
     case Config_ValueType.STRING:
       return value;
@@ -183,7 +183,7 @@ export const unwrapValue = ({
   value: ConfigValue;
   hashByPropertyValue: HashByPropertyValue;
   primitivesOnly: boolean;
-  config?: Config;
+  config?: MinimumConfig;
   resolver?: Resolver;
 }): Omit<UnwrappedValue, "reportableValue"> => {
   if (primitivesOnly) {
@@ -241,7 +241,11 @@ export const unwrapValue = ({
     case "logLevel":
       return { value: value.logLevel };
     default:
-      throw new Error(`Unexpected value ${JSON.stringify(value)}`);
+      throw new Error(
+        `Unexpected value ${JSON.stringify(value)} | kind=${JSON.stringify(
+          kind
+        )}`
+      );
   }
 };
 
@@ -257,7 +261,7 @@ export const unwrap = ({
   value: ConfigValue | undefined;
   hashByPropertyValue?: HashByPropertyValue;
   primitivesOnly?: boolean;
-  config?: Config;
+  config?: MinimumConfig;
   resolver?: Resolver;
 }): UnwrappedValue => {
   if (value === undefined) {

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -1,4 +1,5 @@
 import type { ConfigValue, StringList } from "./proto";
+import { Config_ValueType } from "./proto";
 
 type ConfigValueKey = keyof ConfigValue;
 
@@ -41,4 +42,27 @@ export const wrap = (value: unknown): Record<string, ConfigValue> => {
   return {
     [valueType(value)]: value as ConfigValue,
   };
+};
+
+export const configValueType = (
+  value: ConfigValue
+): Config_ValueType | undefined => {
+  switch (Object.keys(value)[0]) {
+    case "string":
+      return Config_ValueType.STRING;
+    case "int":
+      return Config_ValueType.INT;
+    case "double":
+      return Config_ValueType.DOUBLE;
+    case "bool":
+      return Config_ValueType.BOOL;
+    case "stringList":
+      return Config_ValueType.STRING_LIST;
+    case "logLevel":
+      return Config_ValueType.LOG_LEVEL;
+    case "intRange":
+      return Config_ValueType.INT_RANGE;
+    default:
+      return undefined;
+  }
 };


### PR DESCRIPTION
This allows for setting run-time config. This is especially useful for
setting `prefab.secrets.encryption.key` at run-time.

example:

```javascript
// pass a config key string and a ConfigValue pair
prefab.set("prefab.secrets.encryption.key", { string: decryptionKey })
```

You can also pass config in to `prefab.init()` as an array of
key/ConfigValue pairs.

Example:

```javascript
prefab.init([
  ["some.number", { int: new Long(19) }],
  ["hello", { string: "world" }],
]);
```
