### PR TITLE
feat: .logger

### DIFF
--- a/src/__tests__/prefab.test.ts
+++ b/src/__tests__/prefab.test.ts
@@ -703,6 +703,42 @@ describe("prefab", () => {
     });
   });
 
+  describe("logger", () => {
+    it("creates a logger from a path and defaultLevel", () => {
+      const spy = jest.spyOn(console, "log").mockImplementation();
+
+      const loggerName = "a.b.c.d";
+
+      const prefab = new Prefab({
+        apiKey: irrelevant,
+        collectLoggerCounts: false,
+      });
+
+      prefab.setConfig(
+        [levelAt(loggerName, "info")],
+        projectEnvIdUnderTest,
+        new Map()
+      );
+
+      const logger = prefab.logger(loggerName, "info");
+
+      expect(logger.trace("test")).toBeUndefined();
+      expect(logger.debug("test")).toBeUndefined();
+      expect(logger.info("test")).toEqual("INFO  a.b.c.d: test");
+      expect(logger.warn("test")).toEqual("WARN  a.b.c.d: test");
+      expect(logger.error("test")).toEqual("ERROR a.b.c.d: test");
+      expect(logger.fatal("test")).toEqual("FATAL a.b.c.d: test");
+
+      expect(console.log).toHaveBeenCalledTimes(4);
+      expect(spy.mock.calls).toEqual([
+        ["INFO  a.b.c.d: test"],
+        ["WARN  a.b.c.d: test"],
+        ["ERROR a.b.c.d: test"],
+        ["FATAL a.b.c.d: test"],
+      ]);
+    });
+  });
+
   it("can fire onUpdate when the resolver sets config", async () => {
     const mock = jest.fn();
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,13 +3,16 @@ import { type Resolver } from "./resolver";
 
 export const PREFIX = "log-level.";
 
-export type ValidLogLevelName =
-  | "trace"
-  | "debug"
-  | "info"
-  | "warn"
-  | "error"
-  | "fatal";
+const validLogLevelNames = [
+  "trace",
+  "debug",
+  "info",
+  "warn",
+  "error",
+  "fatal",
+] as const;
+
+export type ValidLogLevelName = (typeof validLogLevelNames)[number];
 
 export type ValidLogLevel = 1 | 2 | 3 | 5 | 6 | 9;
 
@@ -76,4 +79,64 @@ export const shouldLog = ({
   }
 
   return defaultLevel <= desiredLevel;
+};
+
+type MadeLogger = Record<
+  ValidLogLevelName,
+  (
+    message: unknown,
+    contexts?: Contexts | ContextObj | undefined
+  ) => string | undefined
+>;
+
+export const makeLogger = ({
+  loggerName,
+  defaultLevel,
+  resolver,
+}: {
+  loggerName: string;
+  defaultLevel: ValidLogLevel;
+  resolver: Resolver;
+}): MadeLogger => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const logger = {} as MadeLogger;
+
+  validLogLevelNames.forEach((levelName) => {
+    const desiredLevel = parseLevel(levelName);
+
+    if (desiredLevel === undefined) {
+      throw new Error(`Invalid level: ${levelName}`);
+    }
+
+    const printableName = (
+      levelName + " ".repeat(5 - levelName.length)
+    ).toUpperCase();
+
+    logger[levelName] = (
+      message: unknown,
+      contexts?: Contexts | ContextObj | undefined
+    ) => {
+      if (
+        shouldLog({
+          loggerName,
+          desiredLevel,
+          defaultLevel,
+          resolver,
+          contexts,
+        })
+      ) {
+        const printableMessage =
+          typeof message === "string" ? message : JSON.stringify(message);
+
+        const output = `${printableName} ${loggerName}: ${printableMessage}`;
+        console.log(output);
+
+        return output;
+      } else {
+        return undefined;
+      }
+    };
+  });
+
+  return logger;
 };

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -23,7 +23,7 @@ import type {
   ConfigRow,
   Provided,
 } from "./proto";
-import { shouldLog, wordLevelToNumber, parseLevel } from "./logger";
+import { makeLogger, shouldLog, wordLevelToNumber, parseLevel } from "./logger";
 import type { ValidLogLevelName, ValidLogLevel } from "./logger";
 import type { GetValue } from "./unwrap";
 import { SSEConnection } from "./sseConnection";
@@ -198,6 +198,25 @@ class Prefab implements PrefabInterface {
 
     setTimeout(() => {
       TelemetryReporter.start(Object.values(this.telemetry));
+    });
+  }
+
+  logger(
+    loggerName: string,
+    defaultLevel?: ValidLogLevelName
+  ): ReturnType<typeof makeLogger> {
+    requireResolver(this.resolver);
+
+    const parsedDefaultLevel = parseLevel(defaultLevel);
+
+    if (parsedDefaultLevel === undefined && defaultLevel !== undefined) {
+      throw new Error(`Invalid default level: ${defaultLevel}`);
+    }
+
+    return makeLogger({
+      loggerName,
+      defaultLevel: parsedDefaultLevel ?? this.defaultLogLevel,
+      resolver: this.resolver,
     });
   }
 


### PR DESCRIPTION
`.logger` takes a logger name and desiredLevel (optional if set at the
Prefab instance-level) and returns an object with the following methods:

- trace
- debug
- info
- warn
- error
- fatal

Example usage:

```typescript
const logger = prefab.logger("netlify.functions.example", "info");

logger.debug("This will not up") // does not log
logger.info("This will show up") // logs INFO  netlify.functions.example: This will show up
logger.error("This will show up") // logs ERROR netlify.functions.example: This will show up
```
