### PR TITLE
feat: logger() should inherit context

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -93,10 +93,12 @@ export const makeLogger = ({
   loggerName,
   defaultLevel,
   resolver,
+  contexts: makeLoggerLevelContexts,
 }: {
   loggerName: string;
   defaultLevel: ValidLogLevel;
   resolver: Resolver;
+  contexts?: Contexts | ContextObj;
 }): MadeLogger => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const logger = {} as MadeLogger;
@@ -112,17 +114,13 @@ export const makeLogger = ({
       levelName + " ".repeat(5 - levelName.length)
     ).toUpperCase();
 
-    logger[levelName] = (
-      message: unknown,
-      contexts?: Contexts | ContextObj | undefined
-    ) => {
+    logger[levelName] = (message: unknown) => {
       if (
-        shouldLog({
+        resolver.shouldLog({
           loggerName,
           desiredLevel,
           defaultLevel,
-          resolver,
-          contexts,
+          contexts: makeLoggerLevelContexts,
         })
       ) {
         const printableMessage =


### PR DESCRIPTION
You have two ways to use context with logger():

- Approach 1: If you initialize it from the inContext-provided variable, you'll get
  a context-bound logger.
- Approach 2: When initializing on your Prefab instance, you can provide
  context.

Approach 1 Example:

```typescript
const result = prefab.inContext({ user: { country: "US" } }, (pf) => {
  // we initialize inside the context
  const logger = pf.logger(loggerName, "info");

  // these calls are bound to the inContext context so they'll evaluate
  // with user.country of "US"
  logger.debug("test")

  // You can initialize a logger with JIT context if you desire
  const jitLogger = pf.logger(loggerName, "info", { user: { country: "FR" } });
  jitLogger.debug("test")
})
```

Approach 2 Example:

```typescript
const logger = prefab.logger(loggerName, optionalDefaultLevel, optionalContexts)

const result = prefab.inContext({ user: { country: "US" } }, (pf) => {
  // these calls are not bound to the inContext context but use
  // optionalContexts (if provided)
  logger.debug("test")
})
```
