### PR TITLE
feat: updateIfStalerThan

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,7 @@ module.exports = {
     project: ["./tsconfig.eslint.json"],
   },
   rules: {
-    "@typescript-eslint/no-var-requires": "off"
+    "@typescript-eslint/no-var-requires": "off",
+    "promise/param-names": "off",
   },
 };


### PR DESCRIPTION
Provide a convenience function for throttling `updateNow` calls based on
a duration in milliseconds. The update is only called if the duration
has passed since the last update was initialized.

e.g. You can call the following in a tight loop and be ensured that
it'll only update if the duration has passed.

```
prefab.updateIfStalerThan(1000); // if stale, update is triggered
prefab.updateIfStalerThan(1000); // since update is already scheduled, this won't fire
prefab.updateIfStalerThan(1000); // ditto
prefab.updateIfStalerThan(1000); // ditto
prefab.updateIfStalerThan(1000); // ditto
prefab.updateIfStalerThan(1000); // ditto
```
