### PR TITLE
fix: send context shapes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: send context shapes by default
+
 ## 0.1.19 - 2024-02-07
 
 - Fix issue with default context introduced in 0.1.18

--- a/src/__tests__/telemetry/contextShapes.test.ts
+++ b/src/__tests__/telemetry/contextShapes.test.ts
@@ -30,8 +30,9 @@ const contexts: Contexts = new Map([
 ]);
 
 describe("contextShapes", () => {
-  it("returns stub if contextUploadMode is not shapeOnly", () => {
-    expect(contextShapes(mockApiClient, "periodicExample")).toBe(stub);
+  it("returns stub if contextUploadMode is not `none`", () => {
+    expect(contextShapes(mockApiClient, "shapeOnly")).not.toBe(stub);
+    expect(contextShapes(mockApiClient, "periodicExample")).not.toBe(stub);
     expect(contextShapes(mockApiClient, "none")).toBe(stub);
   });
 
@@ -160,7 +161,7 @@ describe("contextShapes", () => {
       );
     });
 
-    it("does not record context shapes by default", () => {
+    it("records context shapes by default", () => {
       const prefabWithoutShapes = new Prefab({
         apiKey: irrelevant,
       });
@@ -173,7 +174,14 @@ describe("contextShapes", () => {
       prefabWithoutShapes.get("basic.value", contexts);
 
       expect(prefabWithoutShapes.telemetry.contextShapes.data).toStrictEqual(
-        new Map()
+        new Map(
+          Object.entries({
+            user: {
+              key: 2,
+              randomNumber: 1,
+            },
+          })
+        )
       );
     });
   });

--- a/src/telemetry/contextShapes.ts
+++ b/src/telemetry/contextShapes.ts
@@ -47,7 +47,7 @@ export const contextShapes = (
   namespace?: string,
   maxDataSize: number = MAX_DATA_SIZE
 ): ContextShapeTelemetry => {
-  if (contextUploadMode !== "shapeOnly") {
+  if (contextUploadMode === "none") {
     return stub;
   }
 


### PR DESCRIPTION
In the future, this might be served by periodicExample at the telemetry API-level, but right now we want to send both.
