### PR TITLE
Config deletion fix

### DIFF
--- a/src/__tests__/fixtures/mostlyDeletedConfig.ts
+++ b/src/__tests__/fixtures/mostlyDeletedConfig.ts
@@ -1,0 +1,20 @@
+import Long from "long";
+import type { Config } from "../../proto";
+import { ConfigType } from "../../proto";
+import { irrelevantLong } from "../testHelpers";
+
+// This is technically a deleted config. It has no rows, but its configType is still CONFIG (rather than DELETED)
+
+const config: Config = {
+  id: new Long(999),
+  projectId: irrelevantLong,
+  key: "mostly.deleted.value",
+  changedBy: undefined,
+  rows: [],
+  allowableValues: [],
+  configType: ConfigType.CONFIG,
+  valueType: 1,
+  sendToClientSdk: false,
+};
+
+export default config;

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -118,7 +118,12 @@ class Resolver implements PrefabInterface {
     defaultContext?: Contexts
   ): void {
     for (const config of configs) {
-      if (config.configType !== ConfigType.DELETED) {
+      if (
+        config.configType === ConfigType.DELETED ||
+        config.rows.length === 0
+      ) {
+        this.config.delete(config.key);
+      } else {
         this.config.set(config.key, config);
       }
     }


### PR DESCRIPTION
An in-memory config should be removed when we receive a deleted config
over SSE.
