### PR TITLE
implement number comparison (LT/LTE/GT/GTE)

### DIFF
--- a/src/__tests__/fixtures/propNumericComparison.ts
+++ b/src/__tests__/fixtures/propNumericComparison.ts
@@ -1,0 +1,97 @@
+import Long from "long";
+import {
+  type Config,
+  Config_ValueType,
+  ConfigType,
+  Criterion_CriterionOperator,
+} from "../../proto";
+import { irrelevantLong } from "../testHelpers";
+
+function createConfig(
+  key: string,
+  valueToMatch: object,
+  operator:
+    | Criterion_CriterionOperator.PROP_LESS_THAN
+    | Criterion_CriterionOperator.PROP_LESS_THAN_OR_EQUAL
+    | Criterion_CriterionOperator.PROP_GREATER_THAN
+    | Criterion_CriterionOperator.PROP_GREATER_THAN_OR_EQUAL
+): Config {
+  return {
+    id: new Long(999),
+    projectId: irrelevantLong,
+    key,
+    changedBy: undefined,
+    rows: [
+      {
+        properties: {},
+        values: [
+          {
+            criteria: [
+              {
+                propertyName,
+                operator,
+                valueToMatch, // Directly use the passed object
+              },
+            ],
+            value: {
+              bool: true,
+            },
+          },
+          {
+            criteria: [],
+            value: {
+              bool: false,
+            },
+          },
+        ],
+      },
+    ],
+    allowableValues: [],
+    configType: ConfigType.CONFIG,
+    valueType: Config_ValueType.BOOL,
+    sendToClientSdk: false,
+  };
+}
+export const propertyName: string = "organization.memberCount";
+export const testValueLong = Long.fromInt(100);
+export const testValueDouble = 100.0;
+export const configLessThanInt = createConfig(
+  "prop.lessThanInt",
+  { int: testValueLong },
+  Criterion_CriterionOperator.PROP_LESS_THAN
+); // int type
+export const configLessThanDouble = createConfig(
+  "prop.lessThanDouble",
+  { double: testValueDouble },
+  Criterion_CriterionOperator.PROP_LESS_THAN
+);
+export const configLessThanEqualInt = createConfig(
+  "prop.lessThanEqualInt",
+  { int: testValueLong },
+  Criterion_CriterionOperator.PROP_LESS_THAN_OR_EQUAL
+); // int type
+export const configLessThanEqualDouble = createConfig(
+  "prop.lessThanEqualDouble",
+  { double: testValueDouble },
+  Criterion_CriterionOperator.PROP_LESS_THAN_OR_EQUAL
+);
+export const configGreaterThanInt = createConfig(
+  "prop.greaterThanInt",
+  { int: testValueLong },
+  Criterion_CriterionOperator.PROP_GREATER_THAN
+); // int type
+export const configGreaterThanDouble = createConfig(
+  "prop.greaterThanDouble",
+  { double: testValueDouble },
+  Criterion_CriterionOperator.PROP_GREATER_THAN
+);
+export const configGreaterThanEqualInt = createConfig(
+  "prop.greaterThanEqualInt",
+  { int: testValueLong },
+  Criterion_CriterionOperator.PROP_GREATER_THAN_OR_EQUAL
+); // int type
+export const configGreaterThanEqualDouble = createConfig(
+  "prop.greaterThanEqualDouble",
+  { double: testValueDouble },
+  Criterion_CriterionOperator.PROP_GREATER_THAN_OR_EQUAL
+);

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -159,6 +159,60 @@ const dateValueToLong = (
   return undefined;
 };
 
+const evaluateNumericCriterion = (
+  criterion: Criterion,
+  contexts: Contexts,
+  comparisonFn: (compareResult: number) => boolean
+): boolean => {
+  const contextValue = normalizeNumber(
+    contextLookup(contexts, criterion.propertyName)
+  );
+  const configValue = normalizeNumber(
+    unwrap({ key: "ignored", value: criterion.valueToMatch }).value
+  );
+
+  if (configValue == null || contextValue == null) {
+    return false;
+  }
+  const compareToResult = compareTo(contextValue, configValue);
+  return comparisonFn(compareToResult);
+};
+
+function normalizeNumber(value: unknown): Long | number | null {
+  if (Long.isLong(value)) return value;
+  if (typeof value === "number") return value;
+  return null; // Invalid type
+}
+
+function compareTo(left: number | Long, right: number | Long): number {
+  const leftNum = Long.isLong(left) ? left.toNumber() : left;
+  const rightNum = Long.isLong(right) ? right.toNumber() : right;
+
+  // If either value is a float, use direct number comparison
+  if (!Number.isInteger(leftNum) || !Number.isInteger(rightNum)) {
+    if (leftNum < rightNum) {
+      return -1;
+    } else if (leftNum > rightNum) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  // Both are integers, safe to compare as Longs
+  if (Long.isLong(left) || Long.isLong(right)) {
+    return Long.fromNumber(leftNum).compare(Long.fromNumber(rightNum));
+  }
+
+  if (leftNum < rightNum) {
+    return -1;
+  } else if (leftNum > rightNum) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
 const evaluateDateCriterion = (
   criterion: Criterion,
   contexts: Contexts
@@ -226,6 +280,31 @@ const allCriteriaMatch = (
       // fall through
       case Criterion_CriterionOperator.PROP_BEFORE:
         return evaluateDateCriterion(criterion, contexts);
+      case Criterion_CriterionOperator.PROP_GREATER_THAN:
+        return evaluateNumericCriterion(
+          criterion,
+          contexts,
+          (compareResult) => compareResult > 0
+        );
+      case Criterion_CriterionOperator.PROP_GREATER_THAN_OR_EQUAL:
+        return evaluateNumericCriterion(
+          criterion,
+          contexts,
+          (compareResult) => compareResult >= 0
+        );
+      case Criterion_CriterionOperator.PROP_LESS_THAN:
+        return evaluateNumericCriterion(
+          criterion,
+          contexts,
+          (compareResult) => compareResult < 0
+        );
+      case Criterion_CriterionOperator.PROP_LESS_THAN_OR_EQUAL:
+        return evaluateNumericCriterion(
+          criterion,
+          contexts,
+          (compareResult) => compareResult <= 0
+        );
+
       default:
         throw new Error(
           `Unexpected criteria ${JSON.stringify(criterion.operator)}`


### PR DESCRIPTION
## Description
implement number comparison (LT/LTE/GT/GTE)

## Testing & Validation
see the unit tests. once the remaining operator support for semver comparison is done, this will also be validated by the shared integration test suite

## Rollout
n/a
