### PR TITLE
More efficient config data fetching

### DIFF
--- a/src/__tests__/apiClient.test.ts
+++ b/src/__tests__/apiClient.test.ts
@@ -1,0 +1,221 @@
+import { jest } from "@jest/globals";
+import {
+  fetchWithCache,
+  clearFetchCache,
+  type ApiClient,
+  type InternalFetchArgs,
+} from "../apiClient";
+import type { FetchResult } from "../types";
+
+describe("fetchWithCache", () => {
+  let fetchMock: jest.MockedFunction<(args: InternalFetchArgs) => FetchResult>;
+  let mockApiClient: ApiClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(Date.now());
+    clearFetchCache();
+    fetchMock = jest.fn() as jest.MockedFunction<
+      (args: InternalFetchArgs) => FetchResult
+    >;
+    mockApiClient = { fetch: fetchMock } satisfies ApiClient;
+  });
+  afterEach(() => {
+    fetchMock.mockClear();
+  });
+
+  test("calls fetch and returns the response", async () => {
+    fetchMock.mockResolvedValue({
+      status: 200,
+      arrayBuffer: async () => new ArrayBuffer(10),
+      headers: new Headers(),
+    });
+
+    const args: InternalFetchArgs = {
+      source: "https://example.com",
+      path: "/config",
+      options: {},
+    };
+
+    const response = await fetchWithCache(mockApiClient, args);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: args.source,
+        path: args.path,
+        options: expect.objectContaining(args.options),
+      })
+    );
+    expect(response.status).toBe(200);
+  });
+
+  test("properly parses max-age for cache expiration", async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      arrayBuffer: async () => new ArrayBuffer(10),
+      headers: new Headers({ "Cache-Control": "max-age=600" }), // ✅ Cached for 600 seconds
+    });
+
+    const args: InternalFetchArgs = {
+      source: "https://example.com",
+      path: "/config",
+      options: {},
+    };
+
+    await fetchWithCache(mockApiClient, args); // ✅ First request stores response in cache
+
+    // Simulate time passing below max-age
+    jest.setSystemTime(Date.now() + 5 * 60 * 1000); // 5 minutes later (still within max-age)
+
+    fetchMock.mockClear(); // ✅ Clear call history before second request
+
+    const cachedResponse = await fetchWithCache(mockApiClient, args);
+
+    // ✅ Ensure fetchMock was NOT called again
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // ✅ Ensure the response comes from cache
+    const buffer = await cachedResponse.arrayBuffer();
+    expect(buffer.byteLength).toBe(10);
+  });
+
+  test("respects Cache-Control: no-store (does not cache response)", async () => {
+    fetchMock.mockResolvedValue({
+      status: 200,
+      arrayBuffer: async () => new ArrayBuffer(10),
+      headers: new Headers({ "Cache-Control": "no-store" }),
+    });
+
+    const args: InternalFetchArgs = {
+      source: "https://example.com",
+      path: "/config",
+      options: {},
+    };
+
+    await fetchWithCache(mockApiClient, args);
+
+    fetchMock.mockClear();
+
+    // Second request should NOT use cache and should call API again
+    await fetchWithCache(mockApiClient, args);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // API should be called again
+  });
+
+  test("respects Cache-Control: must-revalidate (forces revalidation)", async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      arrayBuffer: async () => new ArrayBuffer(10),
+      headers: new Headers({
+        "Cache-Control": "must-revalidate",
+        ETag: '"abc123"',
+      }),
+    });
+
+    const args: InternalFetchArgs = {
+      source: "https://example.com",
+      path: "/config",
+      options: {},
+    };
+
+    await fetchWithCache(mockApiClient, args);
+
+    // Mock a revalidation request
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      arrayBuffer: async () => new ArrayBuffer(20),
+      headers: new Headers({ ETag: '"abc123"' }),
+    });
+
+    const response = await fetchWithCache(mockApiClient, args);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // Should call API again
+    expect(response.status).toBe(200);
+    const buffer = await response.arrayBuffer();
+    expect(buffer.byteLength).toBe(20); // Should return updated data
+  });
+
+  test("evicts expired cache entries after max-age", async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      arrayBuffer: async () => new ArrayBuffer(10),
+      headers: new Headers({ "Cache-Control": "max-age=600" }),
+    });
+
+    const args: InternalFetchArgs = {
+      source: "https://example.com",
+      path: "/config",
+      options: {},
+    };
+
+    await fetchWithCache(mockApiClient, args);
+
+    // Simulate time passing beyond max-age (expired)
+    jest.setSystemTime(Date.now() + 700 * 1000); // 700 sec > 600 sec (expired)
+
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      arrayBuffer: async () => new ArrayBuffer(20),
+      headers: new Headers({ ETag: '"abc123"' }),
+    });
+
+    const response = await fetchWithCache(mockApiClient, args);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // Should re-fetch
+    const buffer = await response.arrayBuffer();
+    expect(buffer.byteLength).toBe(20); // New data should be returned
+  });
+
+  test("respects Cache-Control: no-cache (forces revalidation but can use cached data)", async () => {
+    const cachedData = new ArrayBuffer(10);
+
+    // First fetch: returns 200 OK and caches the result
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      arrayBuffer: async () => cachedData,
+      headers: new Headers({ ETag: '"abc123"', "Cache-Control": "no-cache" }),
+    });
+
+    const args: InternalFetchArgs = {
+      source: "https://example.com",
+      path: "/config",
+      options: {},
+    };
+
+    await fetchWithCache(mockApiClient, args);
+
+    // Clear mock call history before second request
+    fetchMock.mockClear();
+
+    // Second request: should send `If-None-Match`, and the server responds with 304
+    fetchMock.mockResolvedValueOnce({
+      status: 304,
+      arrayBuffer: async () => new ArrayBuffer(0), // This should not be used
+      headers: new Headers({ ETag: '"abc123"' }),
+    });
+
+    const response = await fetchWithCache(mockApiClient, args);
+
+    // ✅ Ensure fetchMock was called again (revalidation required)
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: args.source,
+        path: args.path,
+        options: expect.objectContaining({
+          headers: expect.objectContaining({
+            "If-None-Match": '"abc123"',
+          }),
+        }),
+      })
+    );
+
+    // ✅ Ensure response contains cached data
+    expect(response.status).toBe(200);
+
+    // 🔥 Ensure cached `arrayBuffer()` is used
+    const buffer = await response.arrayBuffer();
+    expect(buffer.byteLength).toBe(10); // Should return cached data
+  });
+});

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -38,7 +38,7 @@ export const apiClient = (apiKey: string, fetchFunc: Fetch): InternalFetch => {
 
 export type ApiClient = ReturnType<typeof apiClient>;
 
-const MAX_CACHE_ENTRIES = 100;
+const MAX_CACHE_ENTRIES = 10;
 const cache = new Map<
   string,
   { data?: ArrayBuffer; etag?: string; expiresAt?: number }

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -118,7 +118,9 @@ const fetchWithCache = async (
 
   if (cache.size > MAX_CACHE_ENTRIES) {
     const leastUsedKey = cache.keys().next().value;
-    cache.delete(leastUsedKey);
+    if (leastUsedKey !== undefined) {
+      cache.delete(leastUsedKey);
+    }
   }
   return new Response(responseBuffer, {
     status: response.status,

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -25,8 +25,8 @@ export const apiClient = (apiKey: string, fetchFunc: Fetch): InternalFetch => {
       "Content-Type": "application/x-protobuf",
       Accept: "application/x-protobuf",
     });
-
-    return await fetchFunc(source + path, {
+    const fullUrl = new URL(path, source).toString();
+    return await fetchFunc(fullUrl, {
       ...opts,
       headers,
     });
@@ -37,3 +37,94 @@ export const apiClient = (apiKey: string, fetchFunc: Fetch): InternalFetch => {
 };
 
 export type ApiClient = ReturnType<typeof apiClient>;
+
+const MAX_CACHE_ENTRIES = 100;
+const cache = new Map<
+  string,
+  { data?: ArrayBuffer; etag?: string; expiresAt?: number }
+>();
+export function clearFetchCache(): void {
+  cache.clear();
+}
+
+const fetchWithCache = async (
+  apiClient: InternalFetch,
+  { source, path, options }: InternalFetchArgs
+): FetchResult => {
+  const now = Date.now();
+  const cacheKey = source + path;
+  const cached = cache.get(cacheKey);
+
+  if (
+    cached?.data !== undefined &&
+    cached.expiresAt !== undefined &&
+    now < cached.expiresAt
+  ) {
+    return {
+      status: 200,
+      arrayBuffer: async () => {
+        if (cached.data === undefined) {
+          throw new Error("Cached data is unexpectedly undefined");
+        }
+        return cached.data;
+      },
+      headers: {
+        get: (name: string) => (name === "ETag" ? cached.etag ?? null : null),
+      },
+    };
+  }
+
+  // ✅ Prepare headers for conditional requests
+  const headers: Record<string, string> = { ...(options?.["headers"] ?? {}) };
+  if (cached?.etag !== undefined) {
+    headers["If-None-Match"] = cached.etag;
+  }
+
+  // 🔥 Fetch from the server
+  const response = await apiClient.fetch({
+    source,
+    path,
+    options: { ...options, headers },
+  });
+
+  // ✅ Explicitly assert `response.headers` as `Headers | undefined`
+  const responseHeaders = response["headers"] as Headers | undefined;
+  const cacheControl = responseHeaders?.get("Cache-Control") ?? "";
+  const etag = responseHeaders?.get("ETag") ?? undefined;
+
+  // 🚀 **Handle 304 Not Modified**
+  if (response.status === 304 && cached?.data !== undefined) {
+    return new Response(cached.data, {
+      status: 200, // ✅ Convert 304 to 200 since we're serving cached data
+      statusText: "OK",
+      headers: new Headers({ ETag: cached.etag ?? "", "X-Cache": "HIT" }),
+    });
+  }
+
+  // 🚫 Respect `no-store`: Do not cache this response
+  if (cacheControl.includes("no-store")) {
+    return response;
+  }
+  const maxAgeMatch = cacheControl.match(/max-age=(\d+)/);
+  const maxAge =
+    maxAgeMatch?.[1] !== undefined
+      ? parseInt(maxAgeMatch[1], 10) * 1000
+      : undefined;
+  const expiresAt = maxAge !== undefined ? now + maxAge : undefined;
+
+  // 🔥 Read response body
+  const responseBuffer = await response.arrayBuffer();
+  cache.set(cacheKey, { data: responseBuffer, etag, expiresAt });
+
+  if (cache.size > MAX_CACHE_ENTRIES) {
+    const leastUsedKey = cache.keys().next().value;
+    cache.delete(leastUsedKey);
+  }
+  return new Response(responseBuffer, {
+    status: response.status,
+    statusText: response["statusText"],
+    headers: response["headers"],
+  });
+};
+
+export { fetchWithCache, type InternalFetchArgs };

--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import type Long from "long";
 import type { Config, Configs } from "./proto";
 import { maxLong } from "./maxLong";
-import type { ApiClient } from "./apiClient";
+import { type ApiClient, fetchWithCache } from "./apiClient";
 
 import { unwrapPrimitive } from "./unwrap";
 import type { Contexts, ProjectEnvId } from "./types";
@@ -83,9 +83,10 @@ const loadConfigFromUrl = async ({
   source: string;
   startAtId?: Long;
   apiClient: ApiClient;
+  etag?: string;
 }): ReturnType<typeof loadConfig> => {
   const path = `/api/v1/configs/${startAtId?.toString() ?? 0}`;
-  const response = await apiClient.fetch({ source, path });
+  const response = await fetchWithCache(apiClient, { source, path });
 
   if (response.status === 401) {
     throw new Error(
@@ -95,7 +96,6 @@ const loadConfigFromUrl = async ({
 
   if (response.status === 200) {
     const buffer = await response.arrayBuffer();
-
     const parsed = parseConfigs(buffer);
     return parse(parsed);
   }

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import type Long from "long";
+import Long from "long";
 import { apiClient, type ApiClient } from "./apiClient";
 import { loadConfig } from "./loadConfig";
 import { Resolver, type MinimumConfig } from "./resolver";
@@ -123,6 +123,7 @@ class Prefab implements PrefabInterface {
   readonly telemetry: Telemetry;
   private running = true;
   private pollTimeout?: NodeJS.Timeout;
+  private startAtId = Long.fromInt(0);
 
   constructor({
     apiKey,
@@ -280,11 +281,12 @@ class Prefab implements PrefabInterface {
     return loadConfig({
       sources: this.sources.configSources,
       apiClient: this.apiClient,
-    }).then(({ configs, defaultContext }) => {
+      startAtId: this.startAtId,
+    }).then(({ configs, defaultContext, startAtId }) => {
       if (configs.length > 0) {
         this.resolver?.update(configs, defaultContext);
+        this.startAtId = startAtId;
       }
-
       this.loadingComplete();
     });
   }


### PR DESCRIPTION
## Description
This changes two things to lower the number of bytes our infra needs to serve
1) Keeps track of startAtId and uses that to fetch configuration data in polling mode rather than always using zero
2) Adds a caching wrapper around api client that supports some basic http cache-control header values. This allows us to hide the 304 no-data responses from the core client by serving it up some cached data rather than modifying it to cope with an up-to-date indication

## Testing & Validation
Unit tests on cache implementation
Integration tests also exercise the caching


