### PR TITLE
Declare `long` as a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Install the client
 
 `npm install @prefab-cloud/prefab-cloud-node` or `yarn add @prefab-cloud/prefab-cloud-node`
 
+## Required Peer Dependencies
+
+This library requires the `long` package to handle 64-bit integers properly:
+
+```bash
+npm install long
+# or
+yarn add long
+```
+
+> **Important:** The `long` package must be directly installed in your project. Some environments (particularly Heroku) require this dependency to be in your project's direct dependencies for proper module resolution. Without it, you may encounter issues with integer values being parsed incorrectly.
+
+## Usage
+
 Set up a Prefab client.
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@types/eventsource": "^1.1.11",
         "eventsource": "^2.0.2",
-        "long": "^5.2.3",
         "murmurhash": "^2.0.1",
         "protobufjs": "^7.2.3"
       },
@@ -28,6 +27,7 @@
         "eslint-plugin-promise": "^6.1.1",
         "husky": "^8.0.0",
         "jest": "^29.5.0",
+        "long": "^5.2.3",
         "prettier": "^2.8.8",
         "protobufjs-cli": "^1.1.1",
         "ts-jest": "^29.1.0",
@@ -35,6 +35,9 @@
         "ts-proto": "^2.6.1",
         "typescript": "^5.0.4",
         "yaml": "^2.2.2"
+      },
+      "peerDependencies": {
+        "long": "^5.2.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "husky": "^8.0.0",
     "jest": "^29.5.0",
+    "long": "^5.2.3",
     "prettier": "^2.8.8",
     "protobufjs-cli": "^1.1.1",
     "ts-jest": "^29.1.0",
@@ -47,10 +48,12 @@
     "typescript": "^5.0.4",
     "yaml": "^2.2.2"
   },
+  "peerDependencies": {
+    "long": "^5.2.3"
+  },
   "dependencies": {
     "@types/eventsource": "^1.1.11",
     "eventsource": "^2.0.2",
-    "long": "^5.2.3",
     "murmurhash": "^2.0.1",
     "protobufjs": "^7.2.3"
   }

--- a/src/__tests__/prefab.test.ts
+++ b/src/__tests__/prefab.test.ts
@@ -669,7 +669,11 @@ describe("prefab", () => {
       const results: Record<string, number> = { true: 0, false: 0 };
 
       nTimes(100, () => {
-        results[prefab.isFeatureEnabled("rollout.flag").toString()]++;
+        const enabled = prefab.isFeatureEnabled("rollout.flag").toString();
+        if (results[enabled] === undefined) {
+          results[enabled] = 0;
+        }
+        results[enabled]++;
       });
 
       // The flag has a 10% chance of being true and a 90% chance of being false

--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import type Long from "long";
+import Long from "long";
 import type { Config, Configs } from "./proto";
 import { maxLong } from "./maxLong";
 import { type ApiClient, fetchWithCache } from "./apiClient";
@@ -111,6 +111,20 @@ const parse = (parsed: Configs): Result => {
   }
 
   const configs = parsed.configs ?? [];
+
+  // Check if configs has at least one item and verify if its id is a Long
+  if (configs.length > 0) {
+    const firstConfig = configs[0];
+    if (
+      firstConfig !== undefined &&
+      firstConfig !== null &&
+      !Long.isLong(firstConfig.id)
+    ) {
+      throw new Error(
+        'Prefab requires the "long" package to be in your project. See https://www.npmjs.com/package/long'
+      );
+    }
+  }
 
   const defaultContext = extractDefaultContext(parsed.defaultContext);
 

--- a/src/telemetry/knownLoggers.ts
+++ b/src/telemetry/knownLoggers.ts
@@ -73,7 +73,9 @@ export const knownLoggers = (
         data[loggerName] = {};
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       (data[loggerName] as Record<string, number>)[severity] =
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         ((data[loggerName] as Record<string, number>)[severity] ?? 0) + 1;
     },
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2018",
     "module": "es2015",
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
## Description

This avoids issues with Longs in protos being parsed as numbers on
Heroku w/ pnpm.

If we determine a long has been parsed as a number, we'll error and
tell the user we depend on `long`.

Also fix some linting errors.


## Testing & Validation

- Manual testing
