### PR TITLE
Add `withContext` to get a context-bound resolver

### DIFF
--- a/src/__tests__/prefab.test.ts
+++ b/src/__tests__/prefab.test.ts
@@ -446,6 +446,22 @@ describe("prefab", () => {
         expect(updateResult).toEqual("updated");
       });
     });
+
+    it("withContext returns a resolver with the provided context", () => {
+      const prefab = new Prefab({ apiKey: irrelevant });
+      prefab.setConfig(configs, projectEnvIdUnderTest, new Map());
+
+      // Create a resolver with US context
+      const usResolver = prefab.withContext({ user: { country: "US" } });
+      expect(usResolver.get("prop.is.one.of")).toEqual("correct");
+
+      // Create a resolver with a different context
+      const otherResolver = prefab.withContext({ user: { country: "FR" } });
+      expect(otherResolver.get("prop.is.one.of")).toEqual("default");
+
+      // Original prefab remains unchanged
+      expect(prefab.get("prop.is.one.of")).toEqual("default");
+    });
   });
 
   // While the evaluation logic is best tested in evaluate.test.ts,

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -74,6 +74,7 @@ export interface PrefabInterface {
   }) => boolean;
   telemetry?: Telemetry;
   updateIfStalerThan: (durationInMs: number) => Promise<void> | undefined;
+  withContext: (contexts: Contexts | ContextObj) => Resolver;
 }
 
 export interface Telemetry {
@@ -357,6 +358,12 @@ class Prefab implements PrefabInterface {
     return func(this.resolver.cloneWithContext(contexts));
   }
 
+  withContext(contexts: Contexts | ContextObj): Resolver {
+    requireResolver(this.resolver);
+
+    return this.resolver.cloneWithContext(contexts);
+  }
+
   get(
     key: string,
     contexts?: Contexts | ContextObj,
@@ -472,6 +479,7 @@ export {
   type ConfigValue,
   type Contexts,
   type Provided,
+  type Resolver,
   type ValidLogLevel,
   type ValidLogLevelName,
   wordLevelToNumber,

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -117,6 +117,10 @@ class Resolver implements PrefabInterface {
     );
   }
 
+  withContext(contexts: Contexts | ContextObj): Resolver {
+    return this.cloneWithContext(contexts);
+  }
+
   update(
     configs: Array<Config | MinimumConfig>,
     defaultContext?: Contexts


### PR DESCRIPTION
Compare `inContext` which evaluates a function in a context.
