### PR TITLE
fix: Telemetry hanging after `prefab.close()`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # We use this for a single test that runs Bun for a subprocess
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
       - run: npm ci
       - run: npm run build --if-present
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .eslintcache
 dist
 .envrc
+src/__tests__/temp-test.ts

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -458,6 +458,18 @@ class Prefab implements PrefabInterface {
     if (this.pollTimeout !== undefined && this.pollTimeout !== null) {
       this.pollTimeout.unref();
     }
+
+    // Clear all telemetry timeouts
+    Object.values(this.telemetry).forEach((telemetryComponent) => {
+      // First disable the component
+      telemetryComponent.enabled = false;
+      // Then clear its timeout
+      if (telemetryComponent.timeout !== undefined) {
+        clearTimeout(telemetryComponent.timeout);
+        telemetryComponent.timeout = undefined;
+      }
+    });
+
     this.running = false;
   }
 }

--- a/src/telemetry/reporter.ts
+++ b/src/telemetry/reporter.ts
@@ -5,9 +5,19 @@ import type { Telemetry } from "./types";
 export const now = (): Long => Long.fromNumber(Date.now());
 
 const syncTelemetry = (telemetry: Telemetry, backoff: Backoff): void => {
+  // Exit early if telemetry is disabled
+  if (!telemetry.enabled) {
+    return;
+  }
+
   const delay = backoff.call();
 
   telemetry.timeout = setTimeout(() => {
+    // Check if telemetry is still enabled before attempting to sync
+    if (!telemetry.enabled) {
+      return;
+    }
+
     telemetry.sync().finally(() => {
       syncTelemetry(telemetry, backoff);
     });


### PR DESCRIPTION
## Description

Telemetry timeouts kept prefab running such that you'd need to manually
`process.exit()` to close your script.

## Testing & Validation

- CI
- Tested locally with a script similar to the one now in CI
