### PR TITLE
implements prefab.current-time lookup for all operators

### DIFF
--- a/src/__tests__/contextLookup.test.ts
+++ b/src/__tests__/contextLookup.test.ts
@@ -79,4 +79,13 @@ describe("contextLookup", () => {
     const result = contextLookup(contexts, "custom.isMobile");
     expect(result).toBe(true);
   });
+
+  it("should return current timestamp for prefab.current-time", () => {
+    const result = contextLookup(contexts, "prefab.current-time");
+    const now = +new Date();
+    
+    // Allow for a small time difference (within 100ms) since the test and the function call
+    // might not execute at exactly the same millisecond
+    expect(Math.abs(result as number - now)).toBeLessThan(100);
+  });
 });

--- a/src/contextLookup.ts
+++ b/src/contextLookup.ts
@@ -8,6 +8,11 @@ export const contextLookup = (
     return undefined;
   }
 
+  // Special case for "prefab.current-time" to always return the current timestamp
+  if (propertyName === "prefab.current-time") {
+    return +new Date();
+  }
+
   let [name, key] = propertyName.split(".");
 
   if (key === undefined) {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -123,16 +123,11 @@ const inSegment = (
 };
 
 const inIntRange = (criterion: Criterion, contexts: Contexts): boolean => {
-  const contextsWithCurrentTime = new Map(contexts);
-  const prefabContext = contextsWithCurrentTime.get("prefab") ?? new Map();
-  prefabContext.set("current-time", +new Date());
-  contextsWithCurrentTime.set("prefab", prefabContext);
-
   const start = criterion.valueToMatch?.intRange?.start;
   const end = criterion.valueToMatch?.intRange?.end;
 
   const comparable = contextLookup(
-    contextsWithCurrentTime,
+    contexts,
     criterion.propertyName
   );
 


### PR DESCRIPTION
## Description
implements prefab.current-time lookup for all operators -- it had previously only worked for IN_INT_RANGE

## Testing & Validation
*(Outline the steps needed to be taken to verify the changes.)*

## Rollout
*(Optional section: Provide rollout and rollback procedures, when outside the bounds or requiring additional work beyond standard deployment)*
