### PR TITLE
fix: verify peer dependencies with error on load of package

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,13 +2,12 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -46,4 +45,4 @@ jobs:
         run: node dist/prefab.cjs
 
       - name: Validate esm version
-        run: node dist/prefab.mjs
+        run: PREFAB_SKIP_PEER_DEPENDENCY_CHECK=true node dist/prefab.mjs

--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import Long from "long";
+import type Long from "long";
 import type { Config, Configs } from "./proto";
 import { maxLong } from "./maxLong";
 import { type ApiClient, fetchWithCache } from "./apiClient";
@@ -111,20 +111,6 @@ const parse = (parsed: Configs): Result => {
   }
 
   const configs = parsed.configs ?? [];
-
-  // Check if configs has at least one item and verify if its id is a Long
-  if (configs.length > 0) {
-    const firstConfig = configs[0];
-    if (
-      firstConfig !== undefined &&
-      firstConfig !== null &&
-      !Long.isLong(firstConfig.id)
-    ) {
-      throw new Error(
-        'Prefab requires the "long" package to be in your project. See https://www.npmjs.com/package/long'
-      );
-    }
-  }
 
   const defaultContext = extractDefaultContext(parsed.defaultContext);
 

--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -1,3 +1,4 @@
+import './verifyPeerDependencies';
 import crypto from "crypto";
 import Long from "long";
 import { apiClient, type ApiClient } from "./apiClient";

--- a/src/verifyPeerDependencies.ts
+++ b/src/verifyPeerDependencies.ts
@@ -1,0 +1,11 @@
+try {
+  if (process.env['PREFAB_SKIP_PEER_DEPENDENCY_CHECK'] !== 'true') {
+    require('long');
+  }
+} catch {
+  throw new Error(
+    'Prefab requires the "long" package to be in your project. See https://www.npmjs.com/package/long',
+  );
+}
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,8 @@
     "dist"
   ],
   "compilerOptions": {
-    "target": "es2018",
-    "module": "es2015",
+    "target": "es2020",
+    "module": "es2022",
     "declaration": true,
     "outDir": "./dist",
     "noEmit": false,


### PR DESCRIPTION
## Description
Follow-up to https://github.com/prefab-cloud/prefab-cloud-node/commit/6fb3e3bb2312dd518282e65479acbeddda991fe2 to ensure we don't leverage the library to validate it's loaded. Instead, we now load the `verifyPeerDependencies` module first and blow up with a clean error before starting to execute code.
